### PR TITLE
[chore] WebMvcConfig cors 설정

### DIFF
--- a/src/main/java/com/fittura/global/webmvc/WebMvcConfig.java
+++ b/src/main/java/com/fittura/global/webmvc/WebMvcConfig.java
@@ -8,15 +8,19 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @Configuration
 public class WebMvcConfig implements WebMvcConfigurer {
     @Value("${cors.allowed-origins}")
-    private String allowedOrigins;
+    private String[] allowedOrigins;
 
     @Override
     public void addCorsMappings(CorsRegistry registry) {
+        for(String origin : allowedOrigins) {
+            if ("*".equals(origin)) {
+                throw new IllegalStateException("CORS 설정 오류: allowCredentials(true)와 함께 '*' 오리진은 사용할 수 없습니다. 구체적인 프론트 도메인을 설정하세요.");
+            }
+        }
         registry.addMapping("/**")
                 .allowedOrigins(allowedOrigins)
-                .allowedMethods("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS")
+                .allowedMethods("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS", "HEAD")
                 .allowedHeaders("*")
-                .exposedHeaders("Authorization")
                 .allowCredentials(true)
                 .maxAge(3600);
     }


### PR DESCRIPTION
## 기능 설명
프론트 연동 준비용 기본 CORS 허용

## 주요 사항
- 프론트 연동 준비용 기본 CORS 허용

## 관련 이슈
Closes #7 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* 신기능
  * 글로벌 CORS 구성 추가: 설정된 오리진에서 모든 엔드포인트에 대한 교차 출처 요청 허용.
  * 허용 메서드: GET, POST, PUT, DELETE, PATCH, OPTIONS, HEAD; 모든 헤더 허용.
  * 자격 증명 포함 요청 허용(쿠키/토큰 등), 프리플라이트 응답 캐시 3600초.
  * 보안 검증 추가: 자격 증명 허용 시 와일드카드("*") 오리진 설정 차단.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->