### PR TITLE
[Feat] JWT 토큰 발급/검증 구현

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,21 +25,36 @@ repositories {
 }
 
 dependencies {
+    // Spring Boot Starters
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation("org.springframework.boot:spring-boot-starter-security")
     implementation("org.springframework.boot:spring-boot-starter-validation")
     implementation("org.springframework.boot:spring-boot-starter-web")
+
+    // OpenAPI/Swagger
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9")
+
+    // Common utils
     implementation("org.apache.commons:commons-lang3:3.18.0")
     implementation("me.paulschwarz:spring-dotenv:4.0.0")
+
+    // JWT
+    implementation("io.jsonwebtoken:jjwt-api:0.12.6")
+    runtimeOnly("io.jsonwebtoken:jjwt-impl:0.12.6")
+    runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.12.6")
+
+    // Lombok
     compileOnly("org.projectlombok:lombok")
     annotationProcessor("org.projectlombok:lombok")
 
+    // Dev tools
     developmentOnly("org.springframework.boot:spring-boot-devtools")
 
+    // DB Drivers
     runtimeOnly("com.h2database:h2")
     runtimeOnly("com.mysql:mysql-connector-j")
 
+    // Test
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.springframework.security:spring-security-test")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")

--- a/src/main/java/com/fittura/global/security/JwtTokenProvider.java
+++ b/src/main/java/com/fittura/global/security/JwtTokenProvider.java
@@ -1,0 +1,96 @@
+package com.fittura.global.security;
+
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.security.Key;
+import java.util.Date;
+import java.util.Set;
+
+@Slf4j
+@Component
+public class JwtTokenProvider {
+
+    private static final String ROLES_CLAIM_KEY = "roles";
+
+    private final Key key;
+    private final long accessTokenValidityInMilliseconds;
+    private final long refreshTokenValidityInMilliseconds;
+    private final JwtParser jwtParser;
+
+    public JwtTokenProvider(
+            @Value("${jwt.secret}") String secretKey,
+            @Value("${jwt.access-token-validity-in-seconds}") long accessTokenValidityInSeconds,
+            @Value("${jwt.refresh-token-validity-in-seconds}") long refreshTokenValidityInSeconds
+    ) {
+        // Base64로 인코딩된 secretKey를 디코딩하여 byte 배열로 변환
+        byte[] keyBytes = Decoders.BASE64.decode(secretKey);
+        // HMAC-SHA 알고리즘에 사용할 키를 생성
+        this.key = Keys.hmacShaKeyFor(keyBytes);
+
+        this.accessTokenValidityInMilliseconds = accessTokenValidityInSeconds * 1000;
+        this.refreshTokenValidityInMilliseconds = refreshTokenValidityInSeconds * 1000;
+
+        // 생성된 키를 사용하여 JWT 파서를 빌드
+        this.jwtParser = Jwts.parser().verifyWith((SecretKey) key).build();
+    }
+
+    public String generateAccessToken(String memberId, String memberEmail, Set<String> roles) {
+        return Jwts.builder()
+            .subject(memberId)
+            .claim("email", memberEmail)
+            .claim(ROLES_CLAIM_KEY, roles)
+            .issuedAt(new Date())
+            .expiration(new Date(System.currentTimeMillis() + accessTokenValidityInMilliseconds))
+            .signWith(key)
+            .compact();
+    }
+
+    public String generateRefreshToken(String memberId) {
+        return Jwts.builder()
+            .subject(memberId)
+            .issuedAt(new Date())
+            .expiration(new Date(System.currentTimeMillis() + refreshTokenValidityInMilliseconds))
+            .signWith(key)
+            .compact();
+    }
+
+    public Claims getClaims(String token) {
+        try {
+            // 서명 검증, 토큰 검증 + 파싱
+            return jwtParser
+                .parseSignedClaims(token)
+                .getPayload();
+        } catch (ExpiredJwtException e) {
+            // 토큰이 만료된 경우, 예외 객체에서 Claims를 추출하여 반환
+            return e.getClaims();
+        }
+    }
+
+    public TokenStatus validateToken(String token) {
+        try {
+            jwtParser.parseSignedClaims(token); // 서명 검증, 토큰 검증 + 파싱
+            return TokenStatus.VALID;
+        } catch (SecurityException | MalformedJwtException e) {
+            log.warn("잘못된 JWT 서명입니다.", e);
+            return TokenStatus.INVALID;
+        } catch (ExpiredJwtException e) { // 만료된 JWT 토큰
+            return TokenStatus.EXPIRED;
+        } catch (UnsupportedJwtException e) {
+            log.warn("지원되지 않는 JWT 토큰입니다.", e);
+            return TokenStatus.UNSUPPORTED;
+        } catch (JwtException | IllegalArgumentException e) {
+            log.warn("JWT 토큰이 잘못되었습니다.", e);
+            return TokenStatus.INVALID;
+        }
+    }
+
+    public String getMemberId(String token) {
+        return getClaims(token).getSubject();
+    }
+}

--- a/src/main/java/com/fittura/global/security/JwtTokenProvider.java
+++ b/src/main/java/com/fittura/global/security/JwtTokenProvider.java
@@ -39,7 +39,7 @@ public class JwtTokenProvider {
         this.jwtParser = Jwts.parser().verifyWith(key).build();
     }
 
-    public String generateAccessToken(String memberId, String memberEmail, Set<String> roles) {
+    public String generateAccessToken(String memberId, Set<String> roles) {
         return Jwts.builder()
             .subject(memberId)
             .claim(ROLES_CLAIM_KEY, roles)

--- a/src/main/java/com/fittura/global/security/TokenStatus.java
+++ b/src/main/java/com/fittura/global/security/TokenStatus.java
@@ -1,0 +1,11 @@
+package com.fittura.global.security;
+
+/**
+ * JWT 토큰의 유효성 검사 결과
+ */
+public enum TokenStatus {
+    VALID,          // 유효한 토큰
+    EXPIRED,        // 만료된 토큰
+    INVALID,        // 서명 오류, 형식 오류 등 유효하지 않은 토큰
+    UNSUPPORTED     // 지원되지 않는 형식의 토큰
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -29,3 +29,7 @@ logging:
     org.springframework.transaction.interceptor: INFO
 cors:
   allowed-origins: ${CORS_ALLOWED_ORIGINS}
+jwt:
+  secret: ${CUSTOM_JWT_SECRET_KEY}
+  access-token-validity-in-seconds: 1800
+  refresh-token-validity-in-seconds: 604800


### PR DESCRIPTION
## 기능 설명
JwtTokenProvider 구현

## 주요 사항
- jwt 의존성 추가
- yml에 jwt 설정 추가
- JwtTokenProvider  : 엑세스 토큰, 리프레시 토큰 발급, 검증

## 관련 이슈
Closes #9 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - JWT 기반 액세스/리프레시 토큰 생성·검증 기능 추가(만료·유효·무효·미지원 상태 구분, 역할·이메일 클레임 포함)
  - OpenAPI 기반 API 문서 UI 제공
- Configuration
  - JWT 시크릿과 액세스/리프레시 토큰 유효기간 옵션 추가(환경변수 지원)
- Chores
  - 런타임·개발·컴파일·테스트용 의존성 대거 추가(H2/MySQL 드라이버, DevTools, Lombok, JWT 라이브러리, 유틸·테스트 라이브러리 등)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->