### PR TITLE
feat 인증/인가 실패 핸들러

### DIFF
--- a/src/main/java/com/fittura/global/error/CommonErrorCode.java
+++ b/src/main/java/com/fittura/global/error/CommonErrorCode.java
@@ -8,21 +8,23 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum CommonErrorCode implements ErrorCode {
     // 404
-    NOT_FOUND(HttpStatus.NOT_FOUND.value(), "C4-01", "요청하신 정보를 찾을 수 없습니다."),
+    NOT_FOUND(HttpStatus.NOT_FOUND.value(), "C404-01", "요청하신 정보를 찾을 수 없습니다."),
 
     // 400
-    BAD_REQUEST(HttpStatus.BAD_REQUEST.value(), "C4-02", "잘못된 요청입니다."),
-    VALIDATION_ERROR(HttpStatus.BAD_REQUEST.value(), "C4-03", "유효성 검사에 실패했습니다."),
-    INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST.value(), "C4-04", "유효하지 않은 입력 값입니다."),
-    CONFLICT(HttpStatus.CONFLICT.value(), "C4-05", "리소스 상태 충돌이 발생했습니다."),
-    TOO_MANY_REQUESTS(HttpStatus.TOO_MANY_REQUESTS.value(), "C4-06", "잠시 후 다시 시도하세요."),
+    BAD_REQUEST(HttpStatus.BAD_REQUEST.value(), "C400-01", "잘못된 요청입니다."),
+    VALIDATION_ERROR(HttpStatus.BAD_REQUEST.value(), "C400-02", "유효성 검사에 실패했습니다."),
+    INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST.value(), "C400-03", "유효하지 않은 입력 값입니다."),
 
-    // security 401, 403,
-    FORBIDDEN(HttpStatus.FORBIDDEN.value(), "CS4-01", "접근 권한이 없습니다."),
-    UNAUTHORIZED(HttpStatus.UNAUTHORIZED.value(), "CS4-02", "인증이 필요합니다."),
+    // security 401, 403
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED.value(), "C401-1", "인증이 필요합니다."),
+    FORBIDDEN(HttpStatus.FORBIDDEN.value(), "C403-1", "접근 권한이 없습니다."),
+
+    // 409, 429
+    CONFLICT(HttpStatus.CONFLICT.value(), "C409-01", "리소스 상태 충돌이 발생했습니다."),
+    TOO_MANY_REQUESTS(HttpStatus.TOO_MANY_REQUESTS.value(), "C429-01", "잠시 후 다시 시도하세요."),
 
     // 500
-    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR.value(), "C5-01", "예상치 못한 오류가 발생했습니다.");
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR.value(), "C500-01", "예상치 못한 오류가 발생했습니다.");
 
     private final int status;
     private final String code;

--- a/src/main/java/com/fittura/global/error/CommonErrorCode.java
+++ b/src/main/java/com/fittura/global/error/CommonErrorCode.java
@@ -14,10 +14,12 @@ public enum CommonErrorCode implements ErrorCode {
     BAD_REQUEST(HttpStatus.BAD_REQUEST.value(), "C4-02", "잘못된 요청입니다."),
     VALIDATION_ERROR(HttpStatus.BAD_REQUEST.value(), "C4-03", "유효성 검사에 실패했습니다."),
     INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST.value(), "C4-04", "유효하지 않은 입력 값입니다."),
-    UNAUTHORIZED(HttpStatus.UNAUTHORIZED.value(), "C4-05", "인증이 필요합니다."),
-    FORBIDDEN(HttpStatus.FORBIDDEN.value(), "C4-06", "접근 권한이 없습니다."),
-    CONFLICT(HttpStatus.CONFLICT.value(), "C4-07", "리소스 상태 충돌이 발생했습니다."),
-    TOO_MANY_REQUESTS(HttpStatus.TOO_MANY_REQUESTS.value(), "C4-08", "잠시 후 다시 시도하세요."),
+    CONFLICT(HttpStatus.CONFLICT.value(), "C4-05", "리소스 상태 충돌이 발생했습니다."),
+    TOO_MANY_REQUESTS(HttpStatus.TOO_MANY_REQUESTS.value(), "C4-06", "잠시 후 다시 시도하세요."),
+
+    // security 401, 403,
+    FORBIDDEN(HttpStatus.FORBIDDEN.value(), "CS4-01", "접근 권한이 없습니다."),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED.value(), "CS4-02", "인증이 필요합니다."),
 
     // 500
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR.value(), "C5-01", "예상치 못한 오류가 발생했습니다.");

--- a/src/main/java/com/fittura/global/exceptionhandler/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/fittura/global/exceptionhandler/CustomAccessDeniedHandler.java
@@ -1,0 +1,32 @@
+package com.fittura.global.exceptionhandler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fittura.global.error.CommonErrorCode;
+import com.fittura.global.rsdata.RsData;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+@Component
+@RequiredArgsConstructor
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException, ServletException {
+        RsData<Void> rsData = RsData.error(CommonErrorCode.FORBIDDEN);
+        response.setStatus(rsData.status());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+        response.getWriter().write(objectMapper.writeValueAsString(rsData));
+    }
+}

--- a/src/main/java/com/fittura/global/exceptionhandler/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/fittura/global/exceptionhandler/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,32 @@
+package com.fittura.global.exceptionhandler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fittura.global.error.CommonErrorCode;
+import com.fittura.global.rsdata.RsData;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+@Component
+@RequiredArgsConstructor
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
+        RsData<Void> rsData = RsData.error(CommonErrorCode.UNAUTHORIZED);
+        response.setStatus(rsData.status());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+        response.getWriter().write(objectMapper.writeValueAsString(rsData));
+    }
+}

--- a/src/main/java/com/fittura/global/rsdata/RsData.java
+++ b/src/main/java/com/fittura/global/rsdata/RsData.java
@@ -9,7 +9,7 @@ public record RsData<T>(
         String message,
         T data
 ) {
-    private static final String DEFAULT_SUCCESS_CODE = "S-01";
+    private static final String DEFAULT_SUCCESS_CODE = "S200-01";
     private static final String DEFAULT_SUCCESS_MESSAGE = "요청이 성공적으로 처리되었습니다.";
 
     public static RsData<Void> success() {


### PR DESCRIPTION
## 기능 설명
인증/인가 실패 핸들러 구현

## 주요 사항
- AuthenticationEntryPoint 401 핸들러
-AccessDeniedHandler 403 핸들러
- securityconfig 필터체인 추가

## 관련 이슈
Closes #29 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 인증 필요(401) 및 접근 거부(403) 상황에서 일관된 JSON 오류 응답을 제공합니다(상태, 에러 코드, 메시지).
- Refactor
  - 에러 코드 체계를 HTTP 상태군(400/401/403/404/409/429/500 등)에 맞춰 재정비 및 재그룹화했습니다.
- Chores
  - 보안 설정에 커스텀 인증/인가 예외 처리기를 연결해 표준화된 오류 포맷을 적용했습니다.
- Bug Fixes
  - 기본 성공 응답 코드 포맷을 업데이트해 응답 코드 표기가 일관되도록 수정했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->