### PR TITLE
[Fix] pr-auto 라벨 자동화 수정

### DIFF
--- a/.github/workflows/pr-auto.yml
+++ b/.github/workflows/pr-auto.yml
@@ -1,3 +1,4 @@
+---
 name: PR 자동화
 
 on:
@@ -18,25 +19,29 @@ jobs:
         uses: li-sumup/actions-assigner@v1.0.2
 
       - name: 'bug' 라벨 추가
-        if: startsWith(github.event.pull_request.title, '[Fix]') || startsWith(github.event.pull_request.title, '[fix]')
+        if: ${{ startsWith(github.event.pull_request.title, '[Fix]') || 
+                startsWith(github.event.pull_request.title, '[fix]')}}
         uses: actions-ecosystem/action-add-labels@v1
         with:
           labels: bug
 
       - name: 'chore' 라벨 추가
-        if: startsWith(github.event.pull_request.title, '[Chore]') || startsWith(github.event.pull_request.title, '[chore]')
+        if: ${{ startsWith(github.event.pull_request.title, '[Chore]') || 
+                startsWith(github.event.pull_request.title, '[chore]')}}
         uses: actions-ecosystem/action-add-labels@v1
         with:
           labels: chore
 
       - name: 'feature' 라벨 추가
-        if: startsWith(github.event.pull_request.title, '[Feat]') || startsWith(github.event.pull_request.title, '[feat]')
+        if: ${{ startsWith(github.event.pull_request.title, '[Feat]') || 
+                startsWith(github.event.pull_request.title, '[feat]') }}
         uses: actions-ecosystem/action-add-labels@v1
         with:
           labels: feature
 
       - name: 'refactor' 라벨 추가
-        if: startsWith(github.event.pull_request.title, '[Refactor]') || startsWith(github.event.pull_request.title, '[refactor]')
+        if: ${{ startsWith(github.event.pull_request.title, '[Refactor]') || 
+                startsWith(github.event.pull_request.title, '[refactor]') }}
         uses: actions-ecosystem/action-add-labels@v1
         with:
           labels: refactor

--- a/.github/workflows/pr-auto.yml
+++ b/.github/workflows/pr-auto.yml
@@ -18,24 +18,28 @@ jobs:
         uses: li-sumup/actions-assigner@v1.0.2
 
       - name: 'bug' 라벨 추가
-        if: startsWith(github.event.pull_request.title, 'Fix') || startsWith(github.event.pull_request.title, 'fix')
+        if: startsWith(github.event.pull_request.title, '[Fix]') || startsWith(github.event.pull_request.title, '[fix]')
         uses: actions-ecosystem/action-add-labels@v1
-        with: { labels: bug }
+        with:
+          labels: bug
 
       - name: 'chore' 라벨 추가
-        if: startsWith(github.event.pull_request.title, 'Chore') || startsWith(github.event.pull_request.title, 'chore')
+        if: startsWith(github.event.pull_request.title, '[Chore]') || startsWith(github.event.pull_request.title, '[chore]')
         uses: actions-ecosystem/action-add-labels@v1
-        with: { labels: chore }
+        with:
+          labels: chore
 
       - name: 'feature' 라벨 추가
-        if: startsWith(github.event.pull_request.title, 'Feat') || startsWith(github.event.pull_request.title, 'feat')
+        if: startsWith(github.event.pull_request.title, '[Feat]') || startsWith(github.event.pull_request.title, '[feat]')
         uses: actions-ecosystem/action-add-labels@v1
-        with: { labels: feature }
+        with:
+          labels: feature
 
       - name: 'refactor' 라벨 추가
-        if: startsWith(github.event.pull_request.title, 'Refactor') || startsWith(github.event.pull_request.title, 'refactor')
+        if: startsWith(github.event.pull_request.title, '[Refactor]') || startsWith(github.event.pull_request.title, '[refactor]')
         uses: actions-ecosystem/action-add-labels@v1
-        with: { labels: refactor }
+        with:
+          labels: refactor
 
       - name: GitHub 프로젝트에 추가
         uses: actions/add-to-project@v1.0.2

--- a/.github/workflows/pr-auto.yml
+++ b/.github/workflows/pr-auto.yml
@@ -3,7 +3,7 @@ name: PR 자동화
 
 on:
   pull_request:
-    branches: [ develop ]
+    branches: [develop]
     types: [opened, synchronize]
 
 jobs:
@@ -18,30 +18,26 @@ jobs:
       - name: PR 작성자를 담당자로 할당
         uses: li-sumup/actions-assigner@v1.0.2
 
-      - name: 'bug' 라벨 추가
-        if: ${{ startsWith(github.event.pull_request.title, '[Fix]') || 
-                startsWith(github.event.pull_request.title, '[fix]')}}
+      - name: bug 라벨 추가
+        if: ${{ startsWith(github.event.pull_request.title, '[Fix]') || startsWith(github.event.pull_request.title, '[fix]')}}
         uses: actions-ecosystem/action-add-labels@v1
         with:
           labels: bug
 
-      - name: 'chore' 라벨 추가
-        if: ${{ startsWith(github.event.pull_request.title, '[Chore]') || 
-                startsWith(github.event.pull_request.title, '[chore]')}}
+      - name: chore 라벨 추가
+        if: ${{ startsWith(github.event.pull_request.title, '[Chore]') || startsWith(github.event.pull_request.title, '[chore]')}}
         uses: actions-ecosystem/action-add-labels@v1
         with:
           labels: chore
 
-      - name: 'feature' 라벨 추가
-        if: ${{ startsWith(github.event.pull_request.title, '[Feat]') || 
-                startsWith(github.event.pull_request.title, '[feat]') }}
+      - name: feature 라벨 추가
+        if: ${{ startsWith(github.event.pull_request.title, '[Feat]') || startsWith(github.event.pull_request.title, '[feat]') }}
         uses: actions-ecosystem/action-add-labels@v1
         with:
           labels: feature
 
-      - name: 'refactor' 라벨 추가
-        if: ${{ startsWith(github.event.pull_request.title, '[Refactor]') || 
-                startsWith(github.event.pull_request.title, '[refactor]') }}
+      - name: refactor 라벨 추가
+        if: ${{ startsWith(github.event.pull_request.title, '[Refactor]') || startsWith(github.event.pull_request.title, '[refactor]') }}
         uses: actions-ecosystem/action-add-labels@v1
         with:
           labels: refactor

--- a/.github/workflows/pr-auto.yml
+++ b/.github/workflows/pr-auto.yml
@@ -17,16 +17,25 @@ jobs:
       - name: PR 작성자를 담당자로 할당
         uses: li-sumup/actions-assigner@v1.0.2
 
-      - name: PR 라벨 자동화
+      - name: 'bug' 라벨 추가
+        if: startsWith(github.event.pull_request.title, 'Fix') || startsWith(github.event.pull_request.title, 'fix')
         uses: actions-ecosystem/action-add-labels@v1
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          # PR 제목에 따라 라벨 자동 지정
-          labels: |
-            ${{ github.event.pull_request.title.startsWith('[fix]') && 'bug' || 
-               github.event.pull_request.title.startsWith('[chore]') && 'chore' || 
-               github.event.pull_request.title.startsWith('[feat]') && 'feature' || 
-               github.event.pull_request.title.startsWith('[refactor]') && 'refactor' }}
+        with: { labels: bug }
+
+      - name: 'chore' 라벨 추가
+        if: startsWith(github.event.pull_request.title, 'Chore') || startsWith(github.event.pull_request.title, 'chore')
+        uses: actions-ecosystem/action-add-labels@v1
+        with: { labels: chore }
+
+      - name: 'feature' 라벨 추가
+        if: startsWith(github.event.pull_request.title, 'Feat') || startsWith(github.event.pull_request.title, 'feat')
+        uses: actions-ecosystem/action-add-labels@v1
+        with: { labels: feature }
+
+      - name: 'refactor' 라벨 추가
+        if: startsWith(github.event.pull_request.title, 'Refactor') || startsWith(github.event.pull_request.title, 'refactor')
+        uses: actions-ecosystem/action-add-labels@v1
+        with: { labels: refactor }
 
       - name: GitHub 프로젝트에 추가
         uses: actions/add-to-project@v1.0.2


### PR DESCRIPTION
## 기능 설명
라벨 자동화 각각 분리

## 주요 사항
- 라벨 자동화 각각 분리

## 관련 이슈
Closes #37 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * PR 라벨 자동화 로직을 개선하여 PR 제목 접두사(Fix/Feat/Refactor/Chore)에 따라 버그/기능/리팩터/잡무 라벨을 개별 조건으로 자동 부여합니다.
  * 대괄호 기반 매핑에서 벗어나 제목 맨앞 단어 검사로 판정 방식을 변경해 가시성과 정확도를 향상했습니다.
  * 각 라벨별로 분리된 단계로 전환하고 github_token 입력을 제거했습니다.
  * 워크플로우 파일 상단에 YAML 시작 구분자(---)를 추가했고 브랜치 필터 표기를 정리했습니다.
  * PR 작성자 할당 및 프로젝트 추가 등 나머지 단계는 변경 없습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->