### PR TITLE
[Feat] 로그아웃 구현

### DIFF
--- a/src/main/java/com/fittura/domain/member/controller/AuthControllerV1.java
+++ b/src/main/java/com/fittura/domain/member/controller/AuthControllerV1.java
@@ -59,10 +59,10 @@ public class AuthControllerV1 {
 
     @PostMapping("/logout")
     @Operation(summary = "로그아웃", description = "로그아웃 API")
-    public RsData<Void> logOut(
+    public RsData<Void> logout(
         HttpServletResponse httpServletResponse
     ) {
-        ResponseCookie cookie = authService.createLogOutCookie();
+        ResponseCookie cookie = authService.createLogoutCookie();
         httpServletResponse.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
 
         return RsData.success(

--- a/src/main/java/com/fittura/domain/member/controller/AuthControllerV1.java
+++ b/src/main/java/com/fittura/domain/member/controller/AuthControllerV1.java
@@ -57,6 +57,20 @@ public class AuthControllerV1 {
         );
     }
 
+    @PostMapping("/logout")
+    @Operation(summary = "로그아웃", description = "로그아웃 API")
+    public RsData<Void> logOut(
+        HttpServletResponse httpServletResponse
+    ) {
+        ResponseCookie cookie = authService.createLogOutCookie();
+        httpServletResponse.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+
+        return RsData.success(
+            "로그아웃되었습니다.",
+            null
+        );
+    }
+
 
     // ========== 헬퍼 메서드 ==========
 
@@ -75,6 +89,6 @@ public class AuthControllerV1 {
         ResponseCookie cookie = authService.generateRefreshTokenCookie(tokenDto);
         httpServletResponse.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
 
-        return AuthResDto.of(authResultDto, tokenDto.accessToken());
+        return AuthResDto.of(authResultDto);
     }
 }

--- a/src/main/java/com/fittura/domain/member/dto/response/AuthResDto.java
+++ b/src/main/java/com/fittura/domain/member/dto/response/AuthResDto.java
@@ -8,12 +8,12 @@ public record AuthResDto(
     String nickname,
     String accessToken
 ) {
-    public static AuthResDto of(AuthResultDto resultDto, String accessToken) {
+    public static AuthResDto of(AuthResultDto resultDto) {
         return new AuthResDto(
             resultDto.id(),
             resultDto.email(),
             resultDto.nickname(),
-            accessToken
+            resultDto.tokenDto().accessToken()
         );
     }
 

--- a/src/main/java/com/fittura/domain/member/service/AuthService.java
+++ b/src/main/java/com/fittura/domain/member/service/AuthService.java
@@ -65,26 +65,16 @@ public class AuthService {
     public ResponseCookie generateRefreshTokenCookie(TokenDto tokenDto) {
         AppProperties.Cookie cookieProps = appProperties.cookie();
 
-        return ResponseCookie.from(cookieProps.refreshTokenName(), tokenDto.refreshToken())
-            .httpOnly(cookieProps.httpOnly())
-            .secure(cookieProps.secure())
-            .domain(cookieProps.domain())
-            .path(cookieProps.path())
+        return baseRefreshCookieBuilder(tokenDto.refreshToken())
             .maxAge(Duration.ofMillis(tokenDto.refreshTokenExpiresInMillis()))
-            .sameSite(cookieProps.sameSite())
             .build();
     }
 
-    public ResponseCookie createLogOutCookie() {
+    public ResponseCookie createLogoutCookie() {
         AppProperties.Cookie cookieProps = appProperties.cookie();
 
-        return ResponseCookie.from(cookieProps.refreshTokenName(), "")
-            .httpOnly(cookieProps.httpOnly())
-            .secure(cookieProps.secure())
-            .domain(cookieProps.domain())
-            .path(cookieProps.path())
-            .maxAge(0)
-            .sameSite(cookieProps.sameSite())
+        return baseRefreshCookieBuilder("")
+            .maxAge(Duration.ZERO)
             .build();
     }
 
@@ -92,5 +82,16 @@ public class AuthService {
         if (!passwordEncoder.matches(req.password(), member.getPassword())) {
             throw new ServiceException(AuthError.INVALID_CREDENTIALS);
         }
+    }
+
+    private ResponseCookie.ResponseCookieBuilder baseRefreshCookieBuilder(String value) {
+        AppProperties.Cookie cookieProps = appProperties.cookie();
+
+        return ResponseCookie.from(cookieProps.refreshTokenName(), value)
+            .httpOnly(cookieProps.httpOnly())
+            .secure(cookieProps.secure())
+            .domain(cookieProps.domain())
+            .path(cookieProps.path())
+            .sameSite(cookieProps.sameSite());
     }
 }

--- a/src/main/java/com/fittura/domain/member/service/AuthService.java
+++ b/src/main/java/com/fittura/domain/member/service/AuthService.java
@@ -75,6 +75,19 @@ public class AuthService {
             .build();
     }
 
+    public ResponseCookie createLogOutCookie() {
+        AppProperties.Cookie cookieProps = appProperties.cookie();
+
+        return ResponseCookie.from(cookieProps.refreshTokenName(), "")
+            .httpOnly(cookieProps.httpOnly())
+            .secure(cookieProps.secure())
+            .domain(cookieProps.domain())
+            .path(cookieProps.path())
+            .maxAge(0)
+            .sameSite(cookieProps.sameSite())
+            .build();
+    }
+
     private void validatePassword(SignInReqDto req, Member member) {
         if (!passwordEncoder.matches(req.password(), member.getPassword())) {
             throw new ServiceException(AuthError.INVALID_CREDENTIALS);

--- a/src/test/java/com/fittura/domain/member/controller/AuthControllerV1Test.java
+++ b/src/test/java/com/fittura/domain/member/controller/AuthControllerV1Test.java
@@ -45,6 +45,7 @@ class AuthControllerV1Test {
 
     private static final String SIGN_UP_URL = "/api/v1/auth/signup";
     private static final String SIGN_IN_URL = "/api/v1/auth/signin";
+    private static final String LOG_OUT_URL = "/api/v1/auth/logout";
 
     @Test
     @DisplayName("회원가입 성공")
@@ -194,8 +195,6 @@ class AuthControllerV1Test {
             )
             .andDo(print());
 
-        String tokenName = appProperties.cookie().refreshTokenName();
-
         // verify
         resultActions
             .andExpect(handler().handlerType(AuthControllerV1.class))
@@ -233,8 +232,6 @@ class AuthControllerV1Test {
             )
             .andDo(print());
 
-        String tokenName = appProperties.cookie().refreshTokenName();
-
         // verify
         resultActions
             .andExpect(handler().handlerType(AuthControllerV1.class))
@@ -243,6 +240,31 @@ class AuthControllerV1Test {
             .andExpect(jsonPath("$.status").value(401))
             .andExpect(jsonPath("$.code").value("A401-01"))
             .andExpect(jsonPath("$.message").value(AuthError.INVALID_CREDENTIALS.getMessage()));
+    }
+
+    @Test
+    @DisplayName("로그아웃 성공")
+    void logoutSuccess() throws Exception {
+        // given
+        String tokenName = appProperties.cookie().refreshTokenName();
+
+        // when
+        ResultActions resultActions = mockMvc
+            .perform(post(LOG_OUT_URL))
+            .andDo(print());
+
+        resultActions
+            .andExpect(handler().handlerType(AuthControllerV1.class))
+            .andExpect(handler().methodName("logOut"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.status").value(200))
+            .andExpect(jsonPath("$.code").value("S200-01"))
+            .andExpect(jsonPath("$.message").value("로그아웃되었습니다."))
+            .andExpect(cookie().exists(tokenName))
+            .andExpect(cookie().value(tokenName, ""))
+            .andExpect(cookie().maxAge(tokenName, 0))
+            .andExpect(cookie().httpOnly(tokenName, appProperties.cookie().httpOnly()))
+            .andExpect(cookie().secure(tokenName, appProperties.cookie().secure()));
     }
 
 

--- a/src/test/java/com/fittura/domain/member/controller/AuthControllerV1Test.java
+++ b/src/test/java/com/fittura/domain/member/controller/AuthControllerV1Test.java
@@ -45,7 +45,7 @@ class AuthControllerV1Test {
 
     private static final String SIGN_UP_URL = "/api/v1/auth/signup";
     private static final String SIGN_IN_URL = "/api/v1/auth/signin";
-    private static final String LOG_OUT_URL = "/api/v1/auth/logout";
+    private static final String LOGOUT_URL = "/api/v1/auth/logout";
 
     @Test
     @DisplayName("회원가입 성공")
@@ -87,7 +87,8 @@ class AuthControllerV1Test {
             .andExpect(cookie().exists(tokenName))
             .andExpect(cookie().httpOnly(tokenName, appProperties.cookie().httpOnly()))
             .andExpect(cookie().secure(tokenName, appProperties.cookie().secure()))
-            .andExpect(cookie().sameSite(tokenName, appProperties.cookie().sameSite()));
+            .andExpect(cookie().sameSite(tokenName, appProperties.cookie().sameSite()))
+            .andExpect(cookie().path(tokenName, appProperties.cookie().path()));
     }
 
     @ParameterizedTest(name = "[{index}] {1}")
@@ -165,7 +166,8 @@ class AuthControllerV1Test {
             .andExpect(cookie().exists(tokenName))
             .andExpect(cookie().httpOnly(tokenName, appProperties.cookie().httpOnly()))
             .andExpect(cookie().secure(tokenName, appProperties.cookie().secure()))
-            .andExpect(cookie().sameSite(tokenName, appProperties.cookie().sameSite()));
+            .andExpect(cookie().sameSite(tokenName, appProperties.cookie().sameSite()))
+            .andExpect(cookie().path(tokenName, appProperties.cookie().path()));
     }
 
     @Test
@@ -250,12 +252,12 @@ class AuthControllerV1Test {
 
         // when
         ResultActions resultActions = mockMvc
-            .perform(post(LOG_OUT_URL))
+            .perform(post(LOGOUT_URL))
             .andDo(print());
 
         resultActions
             .andExpect(handler().handlerType(AuthControllerV1.class))
-            .andExpect(handler().methodName("logOut"))
+            .andExpect(handler().methodName("logout"))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.status").value(200))
             .andExpect(jsonPath("$.code").value("S200-01"))
@@ -264,7 +266,9 @@ class AuthControllerV1Test {
             .andExpect(cookie().value(tokenName, ""))
             .andExpect(cookie().maxAge(tokenName, 0))
             .andExpect(cookie().httpOnly(tokenName, appProperties.cookie().httpOnly()))
-            .andExpect(cookie().secure(tokenName, appProperties.cookie().secure()));
+            .andExpect(cookie().secure(tokenName, appProperties.cookie().secure()))
+            .andExpect(cookie().sameSite(tokenName, appProperties.cookie().sameSite()))
+            .andExpect(cookie().path(tokenName, appProperties.cookie().path()));
     }
 
 


### PR DESCRIPTION
## 기능 설명
로그아웃 구현

## 주요 사항
- 로그아웃 구현
- 리프레시 토큰 쿠키 만료

## 관련 이슈
Closes #20 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* 신기능
  * 로그아웃 엔드포인트가 추가되었습니다. 요청 시 브라우저의 리프레시 토큰 쿠키가 초기화(빈값·만료)되며 성공 메시지를 반환합니다.
* 변경 사항
  * 인증 응답 형식이 조정되어 액세스 토큰이 응답 본문에 포함되지 않습니다.
  * 로그아웃 시 사용되는 쿠키 속성(이름/경로/HttpOnly/secure/sameSite)은 앱 설정을 따릅니다.
* 테스트
  * 로그아웃 성공 시나리오 통합 테스트가 추가되어 응답 코드, 메시지 및 쿠키 초기화 동작을 검증합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->