### PR TITLE
[Feat] 엑세스 토큰 재발급

### DIFF
--- a/src/main/java/com/fittura/domain/member/controller/AuthControllerV1.java
+++ b/src/main/java/com/fittura/domain/member/controller/AuthControllerV1.java
@@ -14,10 +14,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/v1/auth")
@@ -53,6 +50,21 @@ public class AuthControllerV1 {
 
         return RsData.success(
             "로그인되었습니다.",
+            resDto
+        );
+    }
+
+    @PostMapping("/reissue")
+    @Operation(summary = "토큰 재발급", description = "토큰 재발급 API")
+    public RsData<AuthResDto> reissueTokens(
+        @CookieValue(name = "${app.cookie.refresh-token-name}") String refreshToken,
+        HttpServletResponse httpServletResponse
+    ) {
+        AuthResultDto resultDto = authService.reissueTokens(refreshToken);
+        AuthResDto resDto = processAuthResult(resultDto, httpServletResponse);
+
+        return RsData.success(
+            "토큰이 재발급되었습니다.",
             resDto
         );
     }

--- a/src/main/java/com/fittura/domain/member/dto/TokenDto.java
+++ b/src/main/java/com/fittura/domain/member/dto/TokenDto.java
@@ -2,12 +2,10 @@ package com.fittura.domain.member.dto;
 
 public record TokenDto(
     String accessToken,
-    String refreshToken,
-    long refreshTokenExpiresInMillis
+    String refreshToken
 ) {
     @Override
     public String toString() {
-        return "TokenDto[accessToken=****, refreshToken=****, refreshTokenExpiresInMillis=%d]"
-            .formatted(refreshTokenExpiresInMillis);
+        return "TokenDto[accessToken=****, refreshToken=****]";
     }
 }

--- a/src/main/java/com/fittura/domain/member/error/MemberError.java
+++ b/src/main/java/com/fittura/domain/member/error/MemberError.java
@@ -7,10 +7,14 @@ import org.springframework.http.HttpStatus;
 
 @Getter
 @RequiredArgsConstructor
-public enum AuthError implements ErrorCode {
+public enum MemberError implements ErrorCode {
 
     // 401
-    INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED.value(), "A401-01", "이메일 또는 비밀번호를 확인해 주세요"),
+    INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED.value(), "A401-01", "이메일 또는 비밀번호를 확인해 주세요."),
+    INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED.value(), "A401-02", "유효하지 않은 토큰입니다."),
+
+    // 404
+    NOT_FOUND_MEMBER(HttpStatus.NOT_FOUND.value(),  "A404-01", "존재하지 않는 회원입니다."),
 
     // 409
     DUPLICATED_EMAIL(HttpStatus.CONFLICT.value(), "A409-01", "이미 사용중인 이메일입니다."),

--- a/src/main/java/com/fittura/domain/member/error/MemberErrorCode.java
+++ b/src/main/java/com/fittura/domain/member/error/MemberErrorCode.java
@@ -7,11 +7,12 @@ import org.springframework.http.HttpStatus;
 
 @Getter
 @RequiredArgsConstructor
-public enum MemberError implements ErrorCode {
+public enum MemberErrorCode implements ErrorCode {
 
     // 401
     INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED.value(), "A401-01", "이메일 또는 비밀번호를 확인해 주세요."),
     INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED.value(), "A401-02", "유효하지 않은 토큰입니다."),
+    EXPIRED_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED.value(), "A401-03", "토큰이 만료되었습니다. 다시 로그인해 주세요."),
 
     // 404
     NOT_FOUND_MEMBER(HttpStatus.NOT_FOUND.value(),  "A404-01", "존재하지 않는 회원입니다."),

--- a/src/main/java/com/fittura/domain/member/service/AuthService.java
+++ b/src/main/java/com/fittura/domain/member/service/AuthService.java
@@ -5,7 +5,7 @@ import com.fittura.domain.member.dto.TokenDto;
 import com.fittura.domain.member.dto.request.SignInReqDto;
 import com.fittura.domain.member.dto.request.SignUpReqDto;
 import com.fittura.domain.member.entity.Member;
-import com.fittura.domain.member.error.MemberError;
+import com.fittura.domain.member.error.MemberErrorCode;
 import com.fittura.global.config.AppProperties;
 import com.fittura.global.exception.ServiceException;
 import lombok.RequiredArgsConstructor;
@@ -76,7 +76,7 @@ public class AuthService {
 
     public ResponseCookie generateRefreshTokenCookie(TokenDto tokenDto) {
         long refreshTokenExpiresInMillis = tokenService.getRefreshTokenExpiresInMillis();
-        
+
         return baseRefreshCookieBuilder(tokenDto.refreshToken())
             .maxAge(Duration.ofMillis(refreshTokenExpiresInMillis))
             .build();
@@ -93,7 +93,7 @@ public class AuthService {
 
     private void validatePassword(SignInReqDto req, Member member) {
         if (!passwordEncoder.matches(req.password(), member.getPassword())) {
-            throw new ServiceException(MemberError.INVALID_CREDENTIALS);
+            throw new ServiceException(MemberErrorCode.INVALID_CREDENTIALS);
         }
     }
 

--- a/src/main/java/com/fittura/domain/member/service/AuthService.java
+++ b/src/main/java/com/fittura/domain/member/service/AuthService.java
@@ -64,8 +64,8 @@ public class AuthService {
 
     @Transactional(readOnly = true)
     public AuthResultDto reissueTokens(String refreshToken) {
-        String subject = tokenService.findSubjectByRefreshToken(refreshToken);
-        Member member = memberService.findById(Long.parseLong(subject));
+        Long memberId = tokenService.findMemberIdByRefreshToken(refreshToken);
+        Member member = memberService.findById(memberId);
 
         TokenDto tokenDto = tokenService.issueTokens(member);
         return AuthResultDto.of(member, tokenDto);
@@ -75,8 +75,10 @@ public class AuthService {
     // ========== 리프래시 토큰 쿠키 관련 메서드 ==========
 
     public ResponseCookie generateRefreshTokenCookie(TokenDto tokenDto) {
+        long refreshTokenExpiresInMillis = tokenService.getRefreshTokenExpiresInMillis();
+        
         return baseRefreshCookieBuilder(tokenDto.refreshToken())
-            .maxAge(Duration.ofMillis(tokenDto.refreshTokenExpiresInMillis()))
+            .maxAge(Duration.ofMillis(refreshTokenExpiresInMillis))
             .build();
     }
 

--- a/src/main/java/com/fittura/domain/member/service/AuthService.java
+++ b/src/main/java/com/fittura/domain/member/service/AuthService.java
@@ -5,7 +5,7 @@ import com.fittura.domain.member.dto.TokenDto;
 import com.fittura.domain.member.dto.request.SignInReqDto;
 import com.fittura.domain.member.dto.request.SignUpReqDto;
 import com.fittura.domain.member.entity.Member;
-import com.fittura.domain.member.error.AuthError;
+import com.fittura.domain.member.error.MemberError;
 import com.fittura.global.config.AppProperties;
 import com.fittura.global.exception.ServiceException;
 import lombok.RequiredArgsConstructor;
@@ -62,25 +62,36 @@ public class AuthService {
         return AuthResultDto.of(member, tokenDto);
     }
 
-    public ResponseCookie generateRefreshTokenCookie(TokenDto tokenDto) {
-        AppProperties.Cookie cookieProps = appProperties.cookie();
+    @Transactional(readOnly = true)
+    public AuthResultDto reissueTokens(String refreshToken) {
+        String subject = tokenService.findSubjectByRefreshToken(refreshToken);
+        Member member = memberService.findById(Long.parseLong(subject));
 
+        TokenDto tokenDto = tokenService.issueTokens(member);
+        return AuthResultDto.of(member, tokenDto);
+    }
+
+
+    // ========== 리프래시 토큰 쿠키 관련 메서드 ==========
+
+    public ResponseCookie generateRefreshTokenCookie(TokenDto tokenDto) {
         return baseRefreshCookieBuilder(tokenDto.refreshToken())
             .maxAge(Duration.ofMillis(tokenDto.refreshTokenExpiresInMillis()))
             .build();
     }
 
     public ResponseCookie createLogoutCookie() {
-        AppProperties.Cookie cookieProps = appProperties.cookie();
-
         return baseRefreshCookieBuilder("")
             .maxAge(Duration.ZERO)
             .build();
     }
 
+
+    // ========== 헬퍼 메서드 ==========
+
     private void validatePassword(SignInReqDto req, Member member) {
         if (!passwordEncoder.matches(req.password(), member.getPassword())) {
-            throw new ServiceException(AuthError.INVALID_CREDENTIALS);
+            throw new ServiceException(MemberError.INVALID_CREDENTIALS);
         }
     }
 

--- a/src/main/java/com/fittura/domain/member/service/MemberService.java
+++ b/src/main/java/com/fittura/domain/member/service/MemberService.java
@@ -1,7 +1,7 @@
 package com.fittura.domain.member.service;
 
 import com.fittura.domain.member.entity.Member;
-import com.fittura.domain.member.error.MemberError;
+import com.fittura.domain.member.error.MemberErrorCode;
 import com.fittura.domain.member.repository.MemberRepository;
 import com.fittura.global.error.CommonErrorCode;
 import com.fittura.global.exception.ServiceException;
@@ -21,13 +21,13 @@ public class MemberService {
     @Transactional(readOnly = true)
     public Member findById(long id) {
         return memberRepository.findById(id)
-            .orElseThrow(() -> new ServiceException(MemberError.NOT_FOUND_MEMBER));
+            .orElseThrow(() -> new ServiceException(MemberErrorCode.NOT_FOUND_MEMBER));
     }
 
     @Transactional(readOnly = true)
     public Member findByEmail(String email) {
         return memberRepository.findByEmail(email)
-            .orElseThrow(() -> new ServiceException(MemberError.INVALID_CREDENTIALS));
+            .orElseThrow(() -> new ServiceException(MemberErrorCode.INVALID_CREDENTIALS));
     }
 
     @Transactional
@@ -52,13 +52,13 @@ public class MemberService {
 
     public void validateDuplicatedEmail(String email) {
         if (memberRepository.existsByEmail(email)) {
-            throw new ServiceException(MemberError.DUPLICATED_EMAIL);
+            throw new ServiceException(MemberErrorCode.DUPLICATED_EMAIL);
         }
     }
 
     public void validateDuplicatedNickname(String nickname) {
         if (memberRepository.existsByNickname(nickname)) {
-            throw new ServiceException(MemberError.DUPLICATED_NICKNAME);
+            throw new ServiceException(MemberErrorCode.DUPLICATED_NICKNAME);
         }
     }
 }

--- a/src/main/java/com/fittura/domain/member/service/MemberService.java
+++ b/src/main/java/com/fittura/domain/member/service/MemberService.java
@@ -1,7 +1,7 @@
 package com.fittura.domain.member.service;
 
 import com.fittura.domain.member.entity.Member;
-import com.fittura.domain.member.error.AuthError;
+import com.fittura.domain.member.error.MemberError;
 import com.fittura.domain.member.repository.MemberRepository;
 import com.fittura.global.error.CommonErrorCode;
 import com.fittura.global.exception.ServiceException;
@@ -18,9 +18,14 @@ public class MemberService {
 
     private final MemberRepository memberRepository;
 
+    public Member findById(long id) {
+        return memberRepository.findById(id)
+            .orElseThrow(() -> new ServiceException(MemberError.NOT_FOUND_MEMBER));
+    }
+
     public Member findByEmail(String email) {
         return memberRepository.findByEmail(email)
-            .orElseThrow(() -> new ServiceException(AuthError.INVALID_CREDENTIALS));
+            .orElseThrow(() -> new ServiceException(MemberError.INVALID_CREDENTIALS));
     }
 
     @Transactional
@@ -45,13 +50,13 @@ public class MemberService {
 
     public void validateDuplicatedEmail(String email) {
         if (memberRepository.existsByEmail(email)) {
-            throw new ServiceException(AuthError.DUPLICATED_EMAIL);
+            throw new ServiceException(MemberError.DUPLICATED_EMAIL);
         }
     }
 
     public void validateDuplicatedNickname(String nickname) {
         if (memberRepository.existsByNickname(nickname)) {
-            throw new ServiceException(AuthError.DUPLICATED_NICKNAME);
+            throw new ServiceException(MemberError.DUPLICATED_NICKNAME);
         }
     }
 }

--- a/src/main/java/com/fittura/domain/member/service/MemberService.java
+++ b/src/main/java/com/fittura/domain/member/service/MemberService.java
@@ -18,11 +18,13 @@ public class MemberService {
 
     private final MemberRepository memberRepository;
 
+    @Transactional(readOnly = true)
     public Member findById(long id) {
         return memberRepository.findById(id)
             .orElseThrow(() -> new ServiceException(MemberError.NOT_FOUND_MEMBER));
     }
 
+    @Transactional(readOnly = true)
     public Member findByEmail(String email) {
         return memberRepository.findByEmail(email)
             .orElseThrow(() -> new ServiceException(MemberError.INVALID_CREDENTIALS));

--- a/src/main/java/com/fittura/domain/member/service/TokenService.java
+++ b/src/main/java/com/fittura/domain/member/service/TokenService.java
@@ -20,20 +20,27 @@ public class TokenService {
 
     public TokenDto issueTokens(Member savedMember) {
         String memberId = savedMember.getId().toString();
+
         String accessToken = generateAccessToken(savedMember, memberId);
-
         String refreshToken = jwtTokenProvider.generateRefreshToken(memberId);
-        long refreshTokenExpiresInMillis = jwtTokenProvider.getRefreshTokenValidityInMilliseconds();
 
-        return new TokenDto(accessToken, refreshToken, refreshTokenExpiresInMillis);
+        return new TokenDto(accessToken, refreshToken);
     }
 
-    public String findSubjectByRefreshToken(String refreshToken) {
-        TokenStatus tokenStatus = jwtTokenProvider.validateToken(refreshToken);
-        if (tokenStatus != TokenStatus.VALID) {
+    public Long findMemberIdByRefreshToken(String refreshToken) {
+        validateRefreshToken(refreshToken);
+
+        String subject = jwtTokenProvider.getSubject(refreshToken);
+
+        try {
+            return Long.parseLong(subject);
+        } catch (NumberFormatException e) {
             throw new ServiceException(MemberError.INVALID_REFRESH_TOKEN);
         }
-        return jwtTokenProvider.getSubject(refreshToken);
+    }
+
+    public long getRefreshTokenExpiresInMillis() {
+        return jwtTokenProvider.getRefreshTokenValidityInMilliseconds();
     }
 
 
@@ -45,5 +52,15 @@ public class TokenService {
             .map(Enum::name)
             .collect(Collectors.toUnmodifiableSet());
         return jwtTokenProvider.generateAccessToken(memberId, roles);
+    }
+
+    private void validateRefreshToken(String refreshToken) {
+        TokenStatus tokenStatus = jwtTokenProvider.validateToken(refreshToken);
+        if (tokenStatus != TokenStatus.VALID) {
+            throw new ServiceException(MemberError.INVALID_REFRESH_TOKEN);
+        }
+        if (!jwtTokenProvider.isRefreshToken(refreshToken)) {
+            throw new ServiceException(MemberError.INVALID_REFRESH_TOKEN);
+        }
     }
 }

--- a/src/main/java/com/fittura/domain/member/service/TokenService.java
+++ b/src/main/java/com/fittura/domain/member/service/TokenService.java
@@ -2,7 +2,10 @@ package com.fittura.domain.member.service;
 
 import com.fittura.domain.member.dto.TokenDto;
 import com.fittura.domain.member.entity.Member;
+import com.fittura.domain.member.error.MemberError;
+import com.fittura.global.exception.ServiceException;
 import com.fittura.global.security.JwtTokenProvider;
+import com.fittura.global.security.TokenStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -24,6 +27,17 @@ public class TokenService {
 
         return new TokenDto(accessToken, refreshToken, refreshTokenExpiresInMillis);
     }
+
+    public String findSubjectByRefreshToken(String refreshToken) {
+        TokenStatus tokenStatus = jwtTokenProvider.validateToken(refreshToken);
+        if (tokenStatus != TokenStatus.VALID) {
+            throw new ServiceException(MemberError.INVALID_REFRESH_TOKEN);
+        }
+        return jwtTokenProvider.getSubject(refreshToken);
+    }
+
+
+    // ========== 헬퍼 메서드 ==========
 
     private String generateAccessToken(Member savedMember, String memberId) {
         Set<String> roles = savedMember.getRoles()

--- a/src/main/java/com/fittura/domain/member/service/TokenService.java
+++ b/src/main/java/com/fittura/domain/member/service/TokenService.java
@@ -2,7 +2,7 @@ package com.fittura.domain.member.service;
 
 import com.fittura.domain.member.dto.TokenDto;
 import com.fittura.domain.member.entity.Member;
-import com.fittura.domain.member.error.MemberError;
+import com.fittura.domain.member.error.MemberErrorCode;
 import com.fittura.global.exception.ServiceException;
 import com.fittura.global.security.JwtTokenProvider;
 import com.fittura.global.security.TokenStatus;
@@ -35,7 +35,7 @@ public class TokenService {
         try {
             return Long.parseLong(subject);
         } catch (NumberFormatException e) {
-            throw new ServiceException(MemberError.INVALID_REFRESH_TOKEN);
+            throw new ServiceException(MemberErrorCode.INVALID_REFRESH_TOKEN);
         }
     }
 
@@ -56,11 +56,14 @@ public class TokenService {
 
     private void validateRefreshToken(String refreshToken) {
         TokenStatus tokenStatus = jwtTokenProvider.validateToken(refreshToken);
+        if (tokenStatus.equals(TokenStatus.EXPIRED)) {
+            throw new ServiceException(MemberErrorCode.EXPIRED_REFRESH_TOKEN);
+        }
         if (tokenStatus != TokenStatus.VALID) {
-            throw new ServiceException(MemberError.INVALID_REFRESH_TOKEN);
+            throw new ServiceException(MemberErrorCode.INVALID_REFRESH_TOKEN);
         }
         if (!jwtTokenProvider.isRefreshToken(refreshToken)) {
-            throw new ServiceException(MemberError.INVALID_REFRESH_TOKEN);
+            throw new ServiceException(MemberErrorCode.INVALID_REFRESH_TOKEN);
         }
     }
 }

--- a/src/main/java/com/fittura/global/security/JwtTokenProvider.java
+++ b/src/main/java/com/fittura/global/security/JwtTokenProvider.java
@@ -18,6 +18,7 @@ import javax.crypto.SecretKey;
 import java.util.Collection;
 import java.util.Date;
 import java.util.Set;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -61,6 +62,7 @@ public class JwtTokenProvider {
 
     public String generateRefreshToken(String memberId) {
         return Jwts.builder()
+            .id(UUID.randomUUID().toString())
             .subject(memberId)
             .issuedAt(new Date())
             .expiration(new Date(System.currentTimeMillis() + refreshTokenValidityInMilliseconds))

--- a/src/main/java/com/fittura/global/security/JwtTokenProvider.java
+++ b/src/main/java/com/fittura/global/security/JwtTokenProvider.java
@@ -131,4 +131,9 @@ public class JwtTokenProvider {
             return TokenStatus.INVALID;
         }
     }
+
+    public boolean isRefreshToken(String token) {
+        Claims claims = getClaims(token);
+        return claims.get(ROLES_CLAIM_KEY) == null;
+    }
 }

--- a/src/main/java/com/fittura/global/security/JwtTokenProvider.java
+++ b/src/main/java/com/fittura/global/security/JwtTokenProvider.java
@@ -26,6 +26,9 @@ import java.util.stream.Collectors;
 public class JwtTokenProvider {
 
     private static final String ROLES_CLAIM_KEY = "roles";
+    private static final String TOKEN_TYPE_CLAIM_KEY = "token_type";
+    private static final String TOKEN_TYPE_ACCESS = "ACCESS";
+    private static final String TOKEN_TYPE_REFRESH= "REFRESH";
 
     private final SecretKey key;
     private final long accessTokenValidityInMilliseconds;
@@ -54,6 +57,7 @@ public class JwtTokenProvider {
         return Jwts.builder()
             .subject(memberId)
             .claim(ROLES_CLAIM_KEY, roles)
+            .claim(TOKEN_TYPE_CLAIM_KEY, TOKEN_TYPE_ACCESS)
             .issuedAt(new Date())
             .expiration(new Date(System.currentTimeMillis() + accessTokenValidityInMilliseconds))
             .signWith(key)
@@ -64,6 +68,7 @@ public class JwtTokenProvider {
         return Jwts.builder()
             .id(UUID.randomUUID().toString())
             .subject(memberId)
+            .claim(TOKEN_TYPE_CLAIM_KEY, TOKEN_TYPE_REFRESH)
             .issuedAt(new Date())
             .expiration(new Date(System.currentTimeMillis() + refreshTokenValidityInMilliseconds))
             .signWith(key)
@@ -134,6 +139,6 @@ public class JwtTokenProvider {
 
     public boolean isRefreshToken(String token) {
         Claims claims = getClaims(token);
-        return claims.get(ROLES_CLAIM_KEY) == null;
+        return TOKEN_TYPE_REFRESH.equals(claims.get(TOKEN_TYPE_CLAIM_KEY));
     }
 }

--- a/src/test/java/com/fittura/domain/member/controller/AuthControllerV1Test.java
+++ b/src/test/java/com/fittura/domain/member/controller/AuthControllerV1Test.java
@@ -1,9 +1,11 @@
 package com.fittura.domain.member.controller;
 
 import com.fittura.domain.member.entity.Member;
-import com.fittura.domain.member.error.MemberError;
+import com.fittura.domain.member.error.MemberErrorCode;
 import com.fittura.domain.member.repository.MemberRepository;
 import com.fittura.global.config.AppProperties;
+import com.fittura.global.error.CommonErrorCode;
+import com.fittura.global.error.ErrorCode;
 import com.fittura.global.security.JwtTokenProvider;
 import jakarta.servlet.http.Cookie;
 import org.junit.jupiter.api.DisplayName;
@@ -21,6 +23,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Set;
 import java.util.stream.Stream;
 
 import static org.hamcrest.Matchers.equalTo;
@@ -54,6 +57,9 @@ class AuthControllerV1Test {
     private static final String SIGN_IN_URL = "/api/v1/auth/signin";
     private static final String REISSUE_URL = "/api/v1/auth/reissue";
     private static final String LOGOUT_URL = "/api/v1/auth/logout";
+
+
+    // ========== 회원가입 ==========
 
     @Test
     @DisplayName("회원가입 성공")
@@ -94,7 +100,7 @@ class AuthControllerV1Test {
     @ParameterizedTest(name = "[{index}] {1}")
     @DisplayName("회원가입 실패 - 중복 이메일/닉네임")
     @MethodSource("duplicateSignUpInfoProvider")
-    void signUpFailWithDuplication(String reqBody, String testName, MemberError error) throws Exception {
+    void signUpFail_duplication(String reqBody, String testName, MemberErrorCode error) throws Exception {
         // given
         Member existingMember = Member.createUser(
             "test@email.com",
@@ -115,6 +121,9 @@ class AuthControllerV1Test {
         // verify & then
         verifyAuthFailure(resultActions, "signUp", error);
     }
+
+
+    // ========== 로그인 ==========
 
     @Test
     @DisplayName("로그인 성공")
@@ -157,7 +166,7 @@ class AuthControllerV1Test {
 
     @Test
     @DisplayName("로그인 실패 - 존재하지 않는 이메일")
-    void signInFailWithNotExistingEmail() throws Exception {
+    void signInFail_notExistingEmail() throws Exception {
         // given
         Member member = Member.createUser(
             "test@email.com",
@@ -183,12 +192,12 @@ class AuthControllerV1Test {
             .andDo(print());
 
         // verify
-        verifyAuthFailure(resultActions, "signIn", MemberError.INVALID_CREDENTIALS);
+        verifyAuthFailure(resultActions, "signIn", MemberErrorCode.INVALID_CREDENTIALS);
     }
 
     @Test
     @DisplayName("로그인 실패 - 잘못된 비밀번호")
-    void signInFailWithWrongPassword() throws Exception {
+    void signInFail_wrongPassword() throws Exception {
         // given
         Member member = Member.createUser(
             "test@email.com",
@@ -214,8 +223,11 @@ class AuthControllerV1Test {
             .andDo(print());
 
         // verify
-        verifyAuthFailure(resultActions, "signIn", MemberError.INVALID_CREDENTIALS);
+        verifyAuthFailure(resultActions, "signIn", MemberErrorCode.INVALID_CREDENTIALS);
     }
+
+
+    // ========== 토큰 재발급 ==========
 
     @Test
     @DisplayName("토큰 재발급 성공")
@@ -254,6 +266,86 @@ class AuthControllerV1Test {
     }
 
     @Test
+    @DisplayName("토큰 재발급 실패 - 쿠키 누락")
+    void reissueFail_missingCookie() throws Exception {
+        // when & then
+        ResultActions resultActions = mockMvc
+            .perform(post(REISSUE_URL))
+            .andDo(print());
+
+        // verify - Spring의 @CookieValue가 쿠키 누락시 400 에러 발생
+        verifyAuthFailure(resultActions, "reissueTokens", CommonErrorCode.INTERNAL_SERVER_ERROR);
+    }
+
+    @Test
+    @DisplayName("토큰 재발급 실패 - 유효하지 않은 리프레시 토큰")
+    void reissueFail_invalidRefreshToken() throws Exception {
+        // given
+        String invalidToken = jwtTokenProvider.generateRefreshToken("invalid.refresh.token");
+        String tokenName = appProperties.cookie().refreshTokenName();
+        Cookie refreshTokenCookie = new Cookie(tokenName, invalidToken);
+
+        // when & then
+        ResultActions resultActions = mockMvc
+            .perform(post(REISSUE_URL)
+                .cookie(refreshTokenCookie)
+            )
+            .andDo(print());
+
+        // verify
+        verifyAuthFailure(resultActions, "reissueTokens", MemberErrorCode.INVALID_REFRESH_TOKEN);
+    }
+
+    @Test
+    @DisplayName("토큰 재발급 실패 - 존재하지 않는 회원의 토큰")
+    void reissueFail_notExistingMember() throws Exception {
+        // given
+        String invalidToken = jwtTokenProvider.generateRefreshToken("-1");
+        String tokenName = appProperties.cookie().refreshTokenName();
+        Cookie refreshTokenCookie = new Cookie(tokenName, invalidToken);
+
+        // when & then
+        ResultActions resultActions = mockMvc
+            .perform(post(REISSUE_URL)
+                .cookie(refreshTokenCookie)
+            )
+            .andDo(print());
+
+        // verify
+        verifyAuthFailure(resultActions, "reissueTokens", MemberErrorCode.NOT_FOUND_MEMBER);
+    }
+
+    @Test
+    @DisplayName("토큰 재발급 실패 - 엑세스 토큰으로 재발급 시도")
+    void reissueFail_usingAccessToken() throws Exception {
+        // given
+        Member member = Member.createUser(
+            "test@email.com",
+            "유저",
+            "테스트 유저",
+            passwordEncoder.encode("password123!")
+        );
+        memberRepository.save(member);
+
+        String accessToken = jwtTokenProvider.generateAccessToken(member.getId().toString(), Set.of("ROLE_USER"));
+        String tokenName = appProperties.cookie().refreshTokenName();
+        Cookie refreshTokenCookie = new Cookie(tokenName, accessToken);
+
+        // when & then
+        ResultActions resultActions = mockMvc
+            .perform(post(REISSUE_URL)
+                .cookie(refreshTokenCookie)
+            )
+            .andDo(print());
+
+        // verify
+        verifyAuthFailure(resultActions, "reissueTokens", MemberErrorCode.INVALID_REFRESH_TOKEN);
+    }
+
+
+    // ========== 로그아웃 ==========
+
+    @Test
     @DisplayName("로그아웃 성공")
     void logoutSuccess() throws Exception {
         // given
@@ -290,14 +382,14 @@ class AuthControllerV1Test {
                  {"email":"test@email.com","name":"유저","nickname":"다른 유저","password":"password123!"}
                  """,
                 "중복 이메일",
-                MemberError.DUPLICATED_EMAIL
+                MemberErrorCode.DUPLICATED_EMAIL
             ),
             Arguments.of(
                 """
                  {"email":"otherTest@email.com","name":"유저","nickname":"테스트 유저","password":"password123!"}
                  """,
                 "중복 닉네임",
-                MemberError.DUPLICATED_NICKNAME
+                MemberErrorCode.DUPLICATED_NICKNAME
             )
         );
     }
@@ -322,7 +414,7 @@ class AuthControllerV1Test {
             .andExpect(cookie().maxAge(tokenName, maxAge));
     }
 
-    private static void verifyAuthFailure(ResultActions resultActions, String methodName, MemberError error) throws Exception {
+    private static void verifyAuthFailure(ResultActions resultActions, String methodName, ErrorCode error) throws Exception {
         resultActions
             .andExpect(handler().handlerType(AuthControllerV1.class))
             .andExpect(handler().methodName(methodName))

--- a/src/test/java/com/fittura/domain/member/controller/AuthControllerV1Test.java
+++ b/src/test/java/com/fittura/domain/member/controller/AuthControllerV1Test.java
@@ -77,7 +77,6 @@ class AuthControllerV1Test {
 
         Member member = memberRepository.findByEmail("test@email.com")
             .orElseThrow(() -> new AssertionError("회원가입 후 이메일로 회원을 조회하지 못했습니다."));
-        String tokenName = appProperties.cookie().refreshTokenName();
 
         // verify
         resultActions
@@ -86,22 +85,15 @@ class AuthControllerV1Test {
             .andExpect(status().isCreated())
             .andExpect(jsonPath("$.status").value(201))
             .andExpect(jsonPath("$.code").value("S201-01"))
-            .andExpect(jsonPath("$.message").value("회원가입이 완료되었습니다."))
-            .andExpect(jsonPath("$.data.id").value(member.getId()))
-            .andExpect(jsonPath("$.data.email").value(member.getEmail()))
-            .andExpect(jsonPath("$.data.nickname").value(member.getNickname()))
-            .andExpect(jsonPath("$.data.accessToken").exists())
-            .andExpect(cookie().exists(tokenName))
-            .andExpect(cookie().httpOnly(tokenName, appProperties.cookie().httpOnly()))
-            .andExpect(cookie().secure(tokenName, appProperties.cookie().secure()))
-            .andExpect(cookie().sameSite(tokenName, appProperties.cookie().sameSite()))
-            .andExpect(cookie().path(tokenName, appProperties.cookie().path()));
+            .andExpect(jsonPath("$.message").value("회원가입이 완료되었습니다."));
+
+        verifyAuthDataAndCookie(resultActions, member);
     }
 
     @ParameterizedTest(name = "[{index}] {1}")
     @DisplayName("회원가입 실패 - 중복 이메일/닉네임")
     @MethodSource("duplicateSignUpInfoProvider")
-    void signUpFailWithDuplicationEmail(String reqBody, String testName, String errorCode, String errorMessage) throws Exception {
+    void signUpFailWithDuplicationEmail(String reqBody, String testName, MemberError error) throws Exception {
         // given
         Member existingMember = Member.createUser(
             "test@email.com",
@@ -119,14 +111,8 @@ class AuthControllerV1Test {
             )
             .andDo(print());
 
-        // then
-        resultActions
-            .andExpect(handler().handlerType(AuthControllerV1.class))
-            .andExpect(handler().methodName("signUp"))
-            .andExpect(status().isConflict())
-            .andExpect(jsonPath("$.status").value(409))
-            .andExpect(jsonPath("$.code").value(errorCode))
-            .andExpect(jsonPath("$.message").value(errorMessage));
+        // verify & then
+        verifyAuthFailure(resultActions, "signUp", error);
     }
 
     @Test
@@ -165,16 +151,9 @@ class AuthControllerV1Test {
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.status").value(200))
             .andExpect(jsonPath("$.code").value("S200-01"))
-            .andExpect(jsonPath("$.message").value("로그인되었습니다."))
-            .andExpect(jsonPath("$.data.id").value(member.getId()))
-            .andExpect(jsonPath("$.data.email").value(member.getEmail()))
-            .andExpect(jsonPath("$.data.nickname").value(member.getNickname()))
-            .andExpect(jsonPath("$.data.accessToken").exists())
-            .andExpect(cookie().exists(tokenName))
-            .andExpect(cookie().httpOnly(tokenName, appProperties.cookie().httpOnly()))
-            .andExpect(cookie().secure(tokenName, appProperties.cookie().secure()))
-            .andExpect(cookie().sameSite(tokenName, appProperties.cookie().sameSite()))
-            .andExpect(cookie().path(tokenName, appProperties.cookie().path()));
+            .andExpect(jsonPath("$.message").value("로그인되었습니다."));
+
+        verifyAuthDataAndCookie(resultActions, member);
     }
 
     @Test
@@ -205,13 +184,7 @@ class AuthControllerV1Test {
             .andDo(print());
 
         // verify
-        resultActions
-            .andExpect(handler().handlerType(AuthControllerV1.class))
-            .andExpect(handler().methodName("signIn"))
-            .andExpect(status().isUnauthorized())
-            .andExpect(jsonPath("$.status").value(401))
-            .andExpect(jsonPath("$.code").value("A401-01"))
-            .andExpect(jsonPath("$.message").value(MemberError.INVALID_CREDENTIALS.getMessage()));
+        verifyAuthFailure(resultActions, "signIn", MemberError.INVALID_CREDENTIALS);
     }
 
     @Test
@@ -242,13 +215,7 @@ class AuthControllerV1Test {
             .andDo(print());
 
         // verify
-        resultActions
-            .andExpect(handler().handlerType(AuthControllerV1.class))
-            .andExpect(handler().methodName("signIn"))
-            .andExpect(status().isUnauthorized())
-            .andExpect(jsonPath("$.status").value(401))
-            .andExpect(jsonPath("$.code").value("A401-01"))
-            .andExpect(jsonPath("$.message").value(MemberError.INVALID_CREDENTIALS.getMessage()));
+        verifyAuthFailure(resultActions, "signIn", MemberError.INVALID_CREDENTIALS);
     }
 
     @Test
@@ -282,16 +249,9 @@ class AuthControllerV1Test {
             .andExpect(jsonPath("$.status").value(200))
             .andExpect(jsonPath("$.code").value("S200-01"))
             .andExpect(jsonPath("$.message").value("토큰이 재발급되었습니다."))
-            .andExpect(jsonPath("$.data.id").value(member.getId()))
-            .andExpect(jsonPath("$.data.email").value(member.getEmail()))
-            .andExpect(jsonPath("$.data.nickname").value(member.getNickname()))
-            .andExpect(jsonPath("$.data.accessToken").exists())
-            .andExpect(cookie().exists(tokenName))
-            .andExpect(cookie().value(tokenName, not(equalTo(refreshToken)))) // 새 토큰이 발급되었는지 확인
-            .andExpect(cookie().httpOnly(tokenName, appProperties.cookie().httpOnly()))
-            .andExpect(cookie().secure(tokenName, appProperties.cookie().secure()))
-            .andExpect(cookie().sameSite(tokenName, appProperties.cookie().sameSite()))
-            .andExpect(cookie().path(tokenName, appProperties.cookie().path()));
+            .andExpect(cookie().value(tokenName, not(equalTo(refreshToken)))); // 새 토큰이 발급되었는지 확인
+
+        verifyAuthDataAndCookie(resultActions, member);
     }
 
     @Test
@@ -331,17 +291,43 @@ class AuthControllerV1Test {
                  {"email":"test@email.com","name":"유저","nickname":"다른 유저","password":"password123!"}
                  """,
                 "중복 이메일",
-                "A409-01",
-                "이미 사용중인 이메일입니다."
+                MemberError.DUPLICATED_EMAIL
             ),
             Arguments.of(
                 """
                  {"email":"otherTest@email.com","name":"유저","nickname":"테스트 유저","password":"password123!"}
                  """,
                 "중복 닉네임",
-                "A409-02",
-                "이미 사용중인 닉네임입니다."
+                MemberError.DUPLICATED_NICKNAME
             )
         );
+    }
+
+
+    // ========== 헬퍼 메서드 ==========
+
+    private void verifyAuthDataAndCookie(ResultActions resultActions, Member member) throws Exception {
+        String tokenName = appProperties.cookie().refreshTokenName();
+
+        resultActions
+            .andExpect(jsonPath("$.data.id").value(member.getId()))
+            .andExpect(jsonPath("$.data.email").value(member.getEmail()))
+            .andExpect(jsonPath("$.data.nickname").value(member.getNickname()))
+            .andExpect(jsonPath("$.data.accessToken").exists())
+            .andExpect(cookie().exists(tokenName))
+            .andExpect(cookie().httpOnly(tokenName, appProperties.cookie().httpOnly()))
+            .andExpect(cookie().secure(tokenName, appProperties.cookie().secure()))
+            .andExpect(cookie().sameSite(tokenName, appProperties.cookie().sameSite()))
+            .andExpect(cookie().path(tokenName, appProperties.cookie().path()));
+    }
+
+    private static void verifyAuthFailure(ResultActions resultActions, String methodName, MemberError error) throws Exception {
+        resultActions
+            .andExpect(handler().handlerType(AuthControllerV1.class))
+            .andExpect(handler().methodName(methodName))
+            .andExpect(status().is(error.getStatus()))
+            .andExpect(jsonPath("$.status").value(error.getStatus()))
+            .andExpect(jsonPath("$.code").value(error.getCode()))
+            .andExpect(jsonPath("$.message").value(error.getMessage()));
     }
 }

--- a/src/test/java/com/fittura/domain/member/controller/AuthControllerV1Test.java
+++ b/src/test/java/com/fittura/domain/member/controller/AuthControllerV1Test.java
@@ -42,6 +42,9 @@ class AuthControllerV1Test {
     private AppProperties appProperties;
 
     @Autowired
+    private JwtTokenProvider jwtTokenProvider;
+
+    @Autowired
     private MemberRepository memberRepository;
 
     @Autowired
@@ -51,8 +54,6 @@ class AuthControllerV1Test {
     private static final String SIGN_IN_URL = "/api/v1/auth/signin";
     private static final String REISSUE_URL = "/api/v1/auth/reissue";
     private static final String LOGOUT_URL = "/api/v1/auth/logout";
-    @Autowired
-    private JwtTokenProvider jwtTokenProvider;
 
     @Test
     @DisplayName("회원가입 성공")
@@ -93,7 +94,7 @@ class AuthControllerV1Test {
     @ParameterizedTest(name = "[{index}] {1}")
     @DisplayName("회원가입 실패 - 중복 이메일/닉네임")
     @MethodSource("duplicateSignUpInfoProvider")
-    void signUpFailWithDuplicationEmail(String reqBody, String testName, MemberError error) throws Exception {
+    void signUpFailWithDuplication(String reqBody, String testName, MemberError error) throws Exception {
         // given
         Member existingMember = Member.createUser(
             "test@email.com",
@@ -141,8 +142,6 @@ class AuthControllerV1Test {
                 .content(reqBody)
             )
             .andDo(print());
-
-        String tokenName = appProperties.cookie().refreshTokenName();
 
         // verify
         resultActions
@@ -308,6 +307,7 @@ class AuthControllerV1Test {
 
     private void verifyAuthDataAndCookie(ResultActions resultActions, Member member) throws Exception {
         String tokenName = appProperties.cookie().refreshTokenName();
+        int maxAge = (int) (jwtTokenProvider.getRefreshTokenValidityInMilliseconds() / 1000);
 
         resultActions
             .andExpect(jsonPath("$.data.id").value(member.getId()))
@@ -318,7 +318,8 @@ class AuthControllerV1Test {
             .andExpect(cookie().httpOnly(tokenName, appProperties.cookie().httpOnly()))
             .andExpect(cookie().secure(tokenName, appProperties.cookie().secure()))
             .andExpect(cookie().sameSite(tokenName, appProperties.cookie().sameSite()))
-            .andExpect(cookie().path(tokenName, appProperties.cookie().path()));
+            .andExpect(cookie().path(tokenName, appProperties.cookie().path()))
+            .andExpect(cookie().maxAge(tokenName, maxAge));
     }
 
     private static void verifyAuthFailure(ResultActions resultActions, String methodName, MemberError error) throws Exception {

--- a/src/test/java/com/fittura/domain/member/controller/AuthControllerV1Test.java
+++ b/src/test/java/com/fittura/domain/member/controller/AuthControllerV1Test.java
@@ -1,9 +1,11 @@
 package com.fittura.domain.member.controller;
 
 import com.fittura.domain.member.entity.Member;
-import com.fittura.domain.member.error.AuthError;
+import com.fittura.domain.member.error.MemberError;
 import com.fittura.domain.member.repository.MemberRepository;
 import com.fittura.global.config.AppProperties;
+import com.fittura.global.security.JwtTokenProvider;
+import jakarta.servlet.http.Cookie;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -21,6 +23,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.stream.Stream;
 
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -45,7 +49,10 @@ class AuthControllerV1Test {
 
     private static final String SIGN_UP_URL = "/api/v1/auth/signup";
     private static final String SIGN_IN_URL = "/api/v1/auth/signin";
+    private static final String REISSUE_URL = "/api/v1/auth/reissue";
     private static final String LOGOUT_URL = "/api/v1/auth/logout";
+    @Autowired
+    private JwtTokenProvider jwtTokenProvider;
 
     @Test
     @DisplayName("회원가입 성공")
@@ -204,7 +211,7 @@ class AuthControllerV1Test {
             .andExpect(status().isUnauthorized())
             .andExpect(jsonPath("$.status").value(401))
             .andExpect(jsonPath("$.code").value("A401-01"))
-            .andExpect(jsonPath("$.message").value(AuthError.INVALID_CREDENTIALS.getMessage()));
+            .andExpect(jsonPath("$.message").value(MemberError.INVALID_CREDENTIALS.getMessage()));
     }
 
     @Test
@@ -241,7 +248,50 @@ class AuthControllerV1Test {
             .andExpect(status().isUnauthorized())
             .andExpect(jsonPath("$.status").value(401))
             .andExpect(jsonPath("$.code").value("A401-01"))
-            .andExpect(jsonPath("$.message").value(AuthError.INVALID_CREDENTIALS.getMessage()));
+            .andExpect(jsonPath("$.message").value(MemberError.INVALID_CREDENTIALS.getMessage()));
+    }
+
+    @Test
+    @DisplayName("토큰 재발급 성공")
+    void reissueSuccess() throws Exception {
+        // given
+        Member member = Member.createUser(
+            "test@email.com",
+            "유저",
+            "테스트 유저",
+            passwordEncoder.encode("password123!")
+        );
+        memberRepository.save(member);
+
+        String refreshToken = jwtTokenProvider.generateRefreshToken(member.getId().toString());
+        String tokenName = appProperties.cookie().refreshTokenName();
+        Cookie refreshTokenCookie = new Cookie(tokenName, refreshToken);
+
+        // when & then
+        ResultActions resultActions = mockMvc
+            .perform(post(REISSUE_URL)
+                .cookie(refreshTokenCookie)
+            )
+            .andDo(print());
+
+        // verify
+        resultActions
+            .andExpect(handler().handlerType(AuthControllerV1.class))
+            .andExpect(handler().methodName("reissueTokens"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.status").value(200))
+            .andExpect(jsonPath("$.code").value("S200-01"))
+            .andExpect(jsonPath("$.message").value("토큰이 재발급되었습니다."))
+            .andExpect(jsonPath("$.data.id").value(member.getId()))
+            .andExpect(jsonPath("$.data.email").value(member.getEmail()))
+            .andExpect(jsonPath("$.data.nickname").value(member.getNickname()))
+            .andExpect(jsonPath("$.data.accessToken").exists())
+            .andExpect(cookie().exists(tokenName))
+            .andExpect(cookie().value(tokenName, not(equalTo(refreshToken)))) // 새 토큰이 발급되었는지 확인
+            .andExpect(cookie().httpOnly(tokenName, appProperties.cookie().httpOnly()))
+            .andExpect(cookie().secure(tokenName, appProperties.cookie().secure()))
+            .andExpect(cookie().sameSite(tokenName, appProperties.cookie().sameSite()))
+            .andExpect(cookie().path(tokenName, appProperties.cookie().path()));
     }
 
     @Test


### PR DESCRIPTION
## 기능 설명
엑세스 토큰 재발급

## 주요 사항
- 엑세스 토큰 재발급

## 관련 이슈
Closes #41 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 쿠키 기반 토큰 재발급 엔드포인트 추가(/api/v1/auth/reissue). 리프레시 토큰을 사용해 액세스/리프레시 토큰을 안전하게 갱신하고 응답에 반환.

- Refactor
  - 인증 오류 코드/메시지 체계 일원화 및 세분화: 유효하지 않은/만료된 리프레시 토큰 구분, 미존재 회원 시 404 응답.
  - 리프레시 토큰에 타입 식별자 부여로 검증 강화.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->