### PR TITLE
 [chore] Testcontainers reuse 적용

### DIFF
--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -1,7 +1,4 @@
 spring:
-  datasource:
-    url: jdbc:tc:mysql:8.0:///fittura_test
-    driver-class-name: org.testcontainers.jdbc.ContainerDatabaseDriver
   jpa:
     show-sql: true
     hibernate:

--- a/src/test/java/com/fittura/domain/category/controller/AdminCategoryControllerV1Test.java
+++ b/src/test/java/com/fittura/domain/category/controller/AdminCategoryControllerV1Test.java
@@ -5,19 +5,16 @@ import com.fittura.domain.category.entity.Category;
 import com.fittura.domain.category.error.CategoryErrorCode;
 import com.fittura.domain.category.repository.CategoryRepository;
 import com.fittura.domain.category.support.CategoryFixture;
+import com.fittura.global.IntegrationTestBase;
 import com.fittura.global.error.CommonErrorCode;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
-import org.springframework.transaction.annotation.Transactional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
@@ -25,11 +22,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WithMockUser(roles = "ADMIN")
-@ActiveProfiles("test")
-@SpringBootTest
-@AutoConfigureMockMvc
-@Transactional
-class AdminCategoryControllerV1Test {
+class AdminCategoryControllerV1Test extends IntegrationTestBase {
     @Autowired
     private MockMvc mockMvc;
 

--- a/src/test/java/com/fittura/domain/member/controller/AuthControllerV1Test.java
+++ b/src/test/java/com/fittura/domain/member/controller/AuthControllerV1Test.java
@@ -3,6 +3,7 @@ package com.fittura.domain.member.controller;
 import com.fittura.domain.member.entity.Member;
 import com.fittura.domain.member.error.MemberErrorCode;
 import com.fittura.domain.member.repository.MemberRepository;
+import com.fittura.global.IntegrationTestBase;
 import com.fittura.global.config.AppProperties;
 import com.fittura.global.error.CommonErrorCode;
 import com.fittura.global.error.ErrorCode;
@@ -14,14 +15,10 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Set;
 import java.util.stream.Stream;
@@ -32,11 +29,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-@ActiveProfiles("test")
-@SpringBootTest
-@AutoConfigureMockMvc
-@Transactional
-class AuthControllerV1Test {
+class AuthControllerV1Test extends IntegrationTestBase {
 
     @Autowired
     private MockMvc mockMvc;

--- a/src/test/java/com/fittura/global/IntegrationTestBase.java
+++ b/src/test/java/com/fittura/global/IntegrationTestBase.java
@@ -1,0 +1,33 @@
+package com.fittura.global;
+
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.transaction.annotation.Transactional;
+import org.testcontainers.containers.MySQLContainer;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Transactional
+public class IntegrationTestBase {
+
+    static final MySQLContainer<?> mysql =
+        new MySQLContainer<>("mysql:8.0")
+            .withDatabaseName("fittura_test")
+            .withReuse(true);
+
+    static {
+        mysql.start();
+    }
+
+    @DynamicPropertySource
+    static void overrideProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", mysql::getJdbcUrl);
+        registry.add("spring.datasource.username", mysql::getUsername);
+        registry.add("spring.datasource.password", mysql::getPassword);
+        registry.add("spring.datasource.driver-class-name", () -> "com.mysql.cj.jdbc.Driver");
+    }
+}


### PR DESCRIPTION
## 기능 설명
테스트 실행마다 도커 컨테이너를 새로 띄우지 않고 기존 컨테이너를 재사용하도록 하는 설정

## 주요 사항
- IntegrationTestBase 추가
- 통합테스트는 IntegrationTestBase 상속 받아 진행

## 관련 이슈
Closes #69 