### PR TITLE
 [feat] 상품 등록 API (관리자)

### DIFF
--- a/src/main/java/com/fittura/domain/category/entity/Category.java
+++ b/src/main/java/com/fittura/domain/category/entity/Category.java
@@ -122,6 +122,10 @@ public class Category extends BaseEntity {
         return this.status == CategoryStatus.ARCHIVED;
     }
 
+    public boolean isLeaf() {
+        return this.children.isEmpty();
+    }
+
 
     // ===== 연관관계 편의 메서드 =====
 

--- a/src/main/java/com/fittura/domain/category/error/CategoryErrorCode.java
+++ b/src/main/java/com/fittura/domain/category/error/CategoryErrorCode.java
@@ -14,6 +14,7 @@ public enum CategoryErrorCode implements ErrorCode {
     NOT_DESCENDANT_PARENT(HttpStatus.BAD_REQUEST, "C400-02", "카테고리 구성이 올바르지 않습니다."),
     NOT_ARCHIVED_PARENT(HttpStatus.BAD_REQUEST, "C400-03", "ARCHIVED 카테고리로 이동할 수 없습니다."),
     PARENT_NOT_ACTIVE(HttpStatus.BAD_REQUEST, "C400-04", "부모 카테고리가 활성 상태가 아니면 활성화할 수 없습니다."),
+    NOT_LEAF_CATEGORY(HttpStatus.BAD_REQUEST, "C400-05", "하위 카테고리에만 상품을 등록할 수 있습니다."),
 
     // 404
     NOT_FOUND_CATEGORY(HttpStatus.NOT_FOUND,  "C404-01", "존재하지 않는 카테고리입니다."),

--- a/src/main/java/com/fittura/domain/category/error/CategoryErrorCode.java
+++ b/src/main/java/com/fittura/domain/category/error/CategoryErrorCode.java
@@ -10,15 +10,15 @@ import org.springframework.http.HttpStatus;
 public enum CategoryErrorCode implements ErrorCode {
 
     // 400
-    NOT_SELF_PARENT(HttpStatus.BAD_REQUEST, "C400-01", "자기 자신을 상위 카테고리로 지정할 수 없습니다."),
-    NOT_DESCENDANT_PARENT(HttpStatus.BAD_REQUEST, "C400-02", "카테고리 구성이 올바르지 않습니다."),
-    NOT_ARCHIVED_PARENT(HttpStatus.BAD_REQUEST, "C400-03", "ARCHIVED 카테고리로 이동할 수 없습니다."),
-    PARENT_NOT_ACTIVE(HttpStatus.BAD_REQUEST, "C400-04", "부모 카테고리가 활성 상태가 아니면 활성화할 수 없습니다."),
-    NOT_LEAF_CATEGORY(HttpStatus.BAD_REQUEST, "C400-05", "하위 카테고리에만 상품을 등록할 수 있습니다."),
+    NOT_SELF_PARENT(HttpStatus.BAD_REQUEST, "CT400-01", "자기 자신을 상위 카테고리로 지정할 수 없습니다."),
+    NOT_DESCENDANT_PARENT(HttpStatus.BAD_REQUEST, "CT400-02", "카테고리 구성이 올바르지 않습니다."),
+    NOT_ARCHIVED_PARENT(HttpStatus.BAD_REQUEST, "CT400-03", "ARCHIVED 카테고리로 이동할 수 없습니다."),
+    PARENT_NOT_ACTIVE(HttpStatus.BAD_REQUEST, "CT400-04", "부모 카테고리가 활성 상태가 아니면 활성화할 수 없습니다."),
+    NOT_LEAF_CATEGORY(HttpStatus.BAD_REQUEST, "CT400-05", "하위 카테고리에만 상품을 등록할 수 있습니다."),
 
     // 404
-    NOT_FOUND_CATEGORY(HttpStatus.NOT_FOUND,  "C404-01", "존재하지 않는 카테고리입니다."),
-    NOT_FOUND_PARENT_CATEGORY(HttpStatus.NOT_FOUND,  "C404-02", "존재하지 않는 상위 카테고리입니다.");
+    NOT_FOUND_CATEGORY(HttpStatus.NOT_FOUND,  "CT404-01", "존재하지 않는 카테고리입니다."),
+    NOT_FOUND_PARENT_CATEGORY(HttpStatus.NOT_FOUND,  "CT404-02", "존재하지 않는 상위 카테고리입니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/fittura/domain/category/error/CategoryErrorCode.java
+++ b/src/main/java/com/fittura/domain/category/error/CategoryErrorCode.java
@@ -15,6 +15,7 @@ public enum CategoryErrorCode implements ErrorCode {
     NOT_ARCHIVED_PARENT(HttpStatus.BAD_REQUEST, "CT400-03", "ARCHIVED 카테고리로 이동할 수 없습니다."),
     PARENT_NOT_ACTIVE(HttpStatus.BAD_REQUEST, "CT400-04", "부모 카테고리가 활성 상태가 아니면 활성화할 수 없습니다."),
     NOT_LEAF_CATEGORY(HttpStatus.BAD_REQUEST, "CT400-05", "하위 카테고리에만 상품을 등록할 수 있습니다."),
+    ARCHIVED_CATEGORY(HttpStatus.BAD_REQUEST, "CT400-06", "ARCHIVED 카테고리는 사용불가 합니다."),
 
     // 404
     NOT_FOUND_CATEGORY(HttpStatus.NOT_FOUND,  "CT404-01", "존재하지 않는 카테고리입니다."),

--- a/src/main/java/com/fittura/domain/product/facade/ProductFacade.java
+++ b/src/main/java/com/fittura/domain/product/facade/ProductFacade.java
@@ -1,0 +1,29 @@
+package com.fittura.domain.product.facade;
+
+import com.fittura.domain.product.product.dto.request.ProductCreateReqDto;
+import com.fittura.domain.product.product.entity.Product;
+import com.fittura.domain.product.product.service.ProductService;
+import com.fittura.domain.product.sku.service.SkuService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class ProductFacade {
+
+    public final ProductService productService;
+    public final SkuService skuService;
+
+    @Transactional
+    public Long createProduct(ProductCreateReqDto reqDto) {
+        Product product = productService.createProduct(reqDto);
+        skuService.createSkus(product, reqDto.skus());
+
+        if (product.isComplete()) {
+            skuService.createCompositions(product, reqDto.compositions());
+        }
+
+        return product.getId();
+    }
+}

--- a/src/main/java/com/fittura/domain/product/facade/ProductFacade.java
+++ b/src/main/java/com/fittura/domain/product/facade/ProductFacade.java
@@ -12,8 +12,8 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class ProductFacade {
 
-    public final ProductService productService;
-    public final SkuService skuService;
+    private final ProductService productService;
+    private final SkuService skuService;
 
     @Transactional
     public Long createProduct(ProductCreateReqDto reqDto) {

--- a/src/main/java/com/fittura/domain/product/product/constant/ImageType.java
+++ b/src/main/java/com/fittura/domain/product/product/constant/ImageType.java
@@ -1,4 +1,4 @@
-package com.fittura.domain.product.constant;
+package com.fittura.domain.product.product.constant;
 
 public enum ImageType {
     MAIN,       // 상품 목록, 상세 페이지 대표 이미지

--- a/src/main/java/com/fittura/domain/product/product/constant/ProductStatus.java
+++ b/src/main/java/com/fittura/domain/product/product/constant/ProductStatus.java
@@ -1,4 +1,4 @@
-package com.fittura.domain.product.constant;
+package com.fittura.domain.product.product.constant;
 
 public enum ProductStatus {
     ACTIVE,        // 노출 O, 구매 O

--- a/src/main/java/com/fittura/domain/product/product/constant/ProductType.java
+++ b/src/main/java/com/fittura/domain/product/product/constant/ProductType.java
@@ -1,4 +1,4 @@
-package com.fittura.domain.product.constant;
+package com.fittura.domain.product.product.constant;
 
 public enum ProductType {
     COMPLETE,  // 완성품 고정 구성

--- a/src/main/java/com/fittura/domain/product/product/controller/AdminProductControllerV1.java
+++ b/src/main/java/com/fittura/domain/product/product/controller/AdminProductControllerV1.java
@@ -1,0 +1,38 @@
+package com.fittura.domain.product.product.controller;
+
+import com.fittura.domain.product.facade.ProductFacade;
+import com.fittura.domain.product.product.dto.request.ProductCreateReqDto;
+import com.fittura.global.rsdata.RsData;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@PreAuthorize("hasRole('ADMIN')")
+@RestController
+@RequestMapping("/api/admin/v1/products")
+@RequiredArgsConstructor
+@Tag(name = "관리자용 제품 API (V1)", description = "관리자용 - 제품 CRUD 관련 API")
+public class AdminProductControllerV1 {
+
+    private final ProductFacade productFacade;
+
+    @PostMapping
+    @Operation(summary = "제품 등록", description = "제품 등록 API")
+    public ResponseEntity<RsData<Long>> createProduct(
+        @RequestBody @Valid ProductCreateReqDto reqDto
+    ) {
+        Long productId = productFacade.createProduct(reqDto);
+
+        return ResponseEntity
+            .status(HttpStatus.CREATED)
+            .body(RsData.createSuccess("제품이 생성되었습니다.", productId));
+    }
+}

--- a/src/main/java/com/fittura/domain/product/product/dto/request/ProductCreateReqDto.java
+++ b/src/main/java/com/fittura/domain/product/product/dto/request/ProductCreateReqDto.java
@@ -12,7 +12,7 @@ import jakarta.validation.constraints.Size;
 
 import java.util.List;
 
-@Schema(description = "완제품 생성 요청 DTO")
+@Schema(description = "상품 생성 요청 DTO")
 public record ProductCreateReqDto(
 
     @Schema(example = "1")

--- a/src/main/java/com/fittura/domain/product/product/dto/request/ProductCreateReqDto.java
+++ b/src/main/java/com/fittura/domain/product/product/dto/request/ProductCreateReqDto.java
@@ -1,0 +1,47 @@
+package com.fittura.domain.product.product.dto.request;
+
+import com.fittura.domain.product.product.constant.ProductType;
+import com.fittura.domain.product.sku.dto.request.CompositionCreateReqDto;
+import com.fittura.domain.product.sku.dto.request.SkuCreateReqDto;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
+import jakarta.validation.constraints.Size;
+
+import java.util.List;
+
+@Schema(description = "완제품 생성 요청 DTO")
+public record ProductCreateReqDto(
+
+    @Schema(example = "1")
+    @NotNull
+    Long categoryId,
+
+    @Schema(example = "북유럽 의자 완제품")
+    @NotBlank
+    @Size(max = 255)
+    String name,
+
+    @Schema(example = "북유럽 스타일의 원목 의자입니다.")
+    String description,
+
+    @Schema(example = "COMPLETE")
+    @NotNull
+    ProductType productType,
+
+    @Schema(example = "100000")
+    @NotNull
+    @PositiveOrZero
+    Long basePrice,
+
+    @Valid
+    @NotNull
+    @Size(min = 1)
+    List<SkuCreateReqDto> skus,
+
+    @Valid
+    List<CompositionCreateReqDto> compositions
+
+) {}

--- a/src/main/java/com/fittura/domain/product/product/dto/request/ProductCreateReqDto.java
+++ b/src/main/java/com/fittura/domain/product/product/dto/request/ProductCreateReqDto.java
@@ -44,4 +44,8 @@ public record ProductCreateReqDto(
     @Valid
     List<CompositionCreateReqDto> compositions
 
-) {}
+) {
+    public ProductCreateReqDto {
+        compositions = compositions != null ? compositions : List.of();
+    }
+}

--- a/src/main/java/com/fittura/domain/product/product/entity/Product.java
+++ b/src/main/java/com/fittura/domain/product/product/entity/Product.java
@@ -5,10 +5,12 @@ import com.fittura.domain.product.product.constant.ProductStatus;
 import com.fittura.domain.product.product.constant.ProductType;
 import com.fittura.global.jpa.entity.BaseEntity;
 import jakarta.persistence.*;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import static lombok.AccessLevel.PROTECTED;
 
+@Getter
 @Entity
 @Table(name = "products")
 @NoArgsConstructor(access = PROTECTED)
@@ -34,4 +36,17 @@ public class Product extends BaseEntity {
 
     @Column(nullable = false)
     private Long basePrice = 0L;
+
+    public static Product create(Category category, String name, String description,
+                                 ProductType productType, Long basePrice) {
+        Product product = new Product();
+        product.name = name;
+        product.description = description;
+        product.productType = productType;
+        product.basePrice = basePrice;
+        product.category = category;
+        product.status = ProductStatus.DISABLED;
+
+        return product;
+    }
 }

--- a/src/main/java/com/fittura/domain/product/product/entity/Product.java
+++ b/src/main/java/com/fittura/domain/product/product/entity/Product.java
@@ -1,8 +1,8 @@
-package com.fittura.domain.product.entity;
+package com.fittura.domain.product.product.entity;
 
 import com.fittura.domain.category.entity.Category;
-import com.fittura.domain.product.constant.ProductStatus;
-import com.fittura.domain.product.constant.ProductType;
+import com.fittura.domain.product.product.constant.ProductStatus;
+import com.fittura.domain.product.product.constant.ProductType;
 import com.fittura.global.jpa.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.NoArgsConstructor;

--- a/src/main/java/com/fittura/domain/product/product/entity/Product.java
+++ b/src/main/java/com/fittura/domain/product/product/entity/Product.java
@@ -37,6 +37,9 @@ public class Product extends BaseEntity {
     @Column(nullable = false)
     private Long basePrice = 0L;
 
+
+    // ===== 생성 =====
+
     public static Product create(Category category, String name, String description,
                                  ProductType productType, Long basePrice) {
         Product product = new Product();
@@ -48,5 +51,13 @@ public class Product extends BaseEntity {
         product.status = ProductStatus.DISABLED;
 
         return product;
+    }
+
+    public boolean isComplete() {
+        return productType == ProductType.COMPLETE;
+    }
+
+    public boolean isArchived() {
+        return status == ProductStatus.ARCHIVED;
     }
 }

--- a/src/main/java/com/fittura/domain/product/product/entity/Product.java
+++ b/src/main/java/com/fittura/domain/product/product/entity/Product.java
@@ -8,6 +8,8 @@ import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.Objects;
+
 import static lombok.AccessLevel.PROTECTED;
 
 @Getter
@@ -40,8 +42,15 @@ public class Product extends BaseEntity {
 
     // ===== 생성 =====
 
-    public static Product create(Category category, String name, String description,
-                                 ProductType productType, Long basePrice) {
+    public static Product create(
+        Category category,
+        String name,
+        String description,
+        ProductType productType,
+        Long basePrice
+    ) {
+        Objects.requireNonNull(category, "category must not be null");
+
         Product product = new Product();
         product.name = name;
         product.description = description;

--- a/src/main/java/com/fittura/domain/product/product/entity/ProductImage.java
+++ b/src/main/java/com/fittura/domain/product/product/entity/ProductImage.java
@@ -1,6 +1,7 @@
-package com.fittura.domain.product.entity;
+package com.fittura.domain.product.product.entity;
 
-import com.fittura.domain.product.constant.ImageType;
+import com.fittura.domain.product.product.constant.ImageType;
+import com.fittura.domain.product.sku.entity.ProductSku;
 import com.fittura.global.jpa.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.NoArgsConstructor;

--- a/src/main/java/com/fittura/domain/product/product/error/ProductErrorCode.java
+++ b/src/main/java/com/fittura/domain/product/product/error/ProductErrorCode.java
@@ -15,6 +15,7 @@ public enum ProductErrorCode implements ErrorCode {
     CHILD_SKU_ONLY_COMPONENT(HttpStatus.BAD_REQUEST, "P400-03", "완제품의 구성품은 단품 SKU만 등록할 수 있습니다."),
     ARCHIVED_PRODUCT(HttpStatus.BAD_REQUEST, "P400-04", "ARCHIVED 상품은 사용불가 합니다."),
     ARCHIVED_SKU(HttpStatus.BAD_REQUEST, "P400-05", "ARCHIVED SKU는 사용불가 합니다."),
+    COMPOSITION_QUANTITY_MIN1(HttpStatus.BAD_REQUEST, "P400-06", "구성품은 한 개 이상이어야 합니다."),
 
         // 404
     NOT_FOUND_PRODUCT(HttpStatus.NOT_FOUND, "P404-01", "존재하지 않는 상품입니다."),

--- a/src/main/java/com/fittura/domain/product/product/error/ProductErrorCode.java
+++ b/src/main/java/com/fittura/domain/product/product/error/ProductErrorCode.java
@@ -12,10 +12,11 @@ public enum ProductErrorCode implements ErrorCode {
     // 400
     COMPLETE_HAVE_COMPOSITIONS(HttpStatus.BAD_REQUEST, "P400-01", "완제품은 구성품을 가지고 있어야 합니다."),
     COMPONENT_NOT_HAVE_COMPOSITION(HttpStatus.BAD_REQUEST, "P400-02", "단품은 구성품을 가질 수 없습니다."),
-    COMPOSITION_ONLY_COMPLETE(HttpStatus.BAD_REQUEST, "P400-03", "완제품만 구성품을 구성할 수 있습니다."),
-    CHILD_SKU_ONLY_COMPONENT(HttpStatus.BAD_REQUEST, "P400-04", "완제품의 구성품은 단품 SKU만 등록할 수 있습니다."),
+    CHILD_SKU_ONLY_COMPONENT(HttpStatus.BAD_REQUEST, "P400-03", "완제품의 구성품은 단품 SKU만 등록할 수 있습니다."),
+    ARCHIVED_PRODUCT(HttpStatus.BAD_REQUEST, "P400-04", "ARCHIVED 상품은 사용불가 합니다."),
+    ARCHIVED_SKU(HttpStatus.BAD_REQUEST, "P400-05", "ARCHIVED SKU는 사용불가 합니다."),
 
-    // 404
+        // 404
     NOT_FOUND_PRODUCT(HttpStatus.NOT_FOUND, "P404-01", "존재하지 않는 상품입니다."),
     NOT_FOUND_SKU(HttpStatus.NOT_FOUND, "P404-02", "존재하지 않는 SKU 입니다.");
 

--- a/src/main/java/com/fittura/domain/product/product/error/ProductErrorCode.java
+++ b/src/main/java/com/fittura/domain/product/product/error/ProductErrorCode.java
@@ -1,0 +1,25 @@
+package com.fittura.domain.product.product.error;
+
+import com.fittura.global.error.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ProductErrorCode implements ErrorCode {
+
+    // 400
+    COMPLETE_HAVE_COMPOSITIONS(HttpStatus.BAD_REQUEST, "P400-01", "완제품은 구성품을 가지고 있어야 합니다."),
+    COMPONENT_NOT_HAVE_COMPOSITION(HttpStatus.BAD_REQUEST, "P400-02", "단품은 구성품을 가질 수 없습니다."),
+    COMPOSITION_ONLY_COMPLETE(HttpStatus.BAD_REQUEST, "P400-03", "완제품만 구성품을 구성할 수 있습니다."),
+    CHILD_SKU_ONLY_COMPONENT(HttpStatus.BAD_REQUEST, "P400-04", "완제품의 구성품은 단품 SKU만 등록할 수 있습니다."),
+
+    // 404
+    NOT_FOUND_PRODUCT(HttpStatus.NOT_FOUND, "P404-01", "존재하지 않는 상품입니다."),
+    NOT_FOUND_SKU(HttpStatus.NOT_FOUND, "P404-02", "존재하지 않는 SKU 입니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/fittura/domain/product/product/repository/ProductRepository.java
+++ b/src/main/java/com/fittura/domain/product/product/repository/ProductRepository.java
@@ -1,0 +1,9 @@
+package com.fittura.domain.product.product.repository;
+
+import com.fittura.domain.product.product.entity.Product;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ProductRepository extends JpaRepository<Product,Long> {
+}

--- a/src/main/java/com/fittura/domain/product/product/service/ProductService.java
+++ b/src/main/java/com/fittura/domain/product/product/service/ProductService.java
@@ -1,0 +1,69 @@
+package com.fittura.domain.product.product.service;
+
+import com.fittura.domain.category.entity.Category;
+import com.fittura.domain.category.error.CategoryErrorCode;
+import com.fittura.domain.category.repository.CategoryRepository;
+import com.fittura.domain.product.product.constant.ProductType;
+import com.fittura.domain.product.product.dto.request.ProductCreateReqDto;
+import com.fittura.domain.product.product.entity.Product;
+import com.fittura.domain.product.product.error.ProductErrorCode;
+import com.fittura.domain.product.product.repository.ProductRepository;
+import com.fittura.global.exception.ServiceException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ProductService {
+
+    private final CategoryRepository categoryRepository;
+    private final ProductRepository productRepository;
+
+    public Product createProduct(ProductCreateReqDto reqDto) {
+        Category category = getCategory(reqDto.categoryId());
+
+        validateCategory(category);
+        validateProductType(reqDto);
+
+        Product product = Product.create(
+            category,
+            reqDto.name(),
+            reqDto.description(),
+            reqDto.productType(),
+            reqDto.basePrice()
+        );
+        productRepository.save(product);
+
+        return product;
+    }
+
+
+    // ===== 유효성 검사 메서드 ====
+
+    private void validateCategory(Category category) {
+        if (category.isArchived()) {
+            throw new ServiceException(CategoryErrorCode.NOT_FOUND_CATEGORY);
+        }
+
+        if (!category.isLeaf()) {
+            throw new ServiceException(CategoryErrorCode.NOT_LEAF_CATEGORY);
+        }
+    }
+
+    private static void validateProductType(ProductCreateReqDto reqDto) {
+        if (reqDto.productType() == ProductType.COMPLETE && reqDto.compositions().isEmpty()) {
+            throw new ServiceException(ProductErrorCode.COMPLETE_HAVE_COMPOSITIONS);
+        }
+        if (reqDto.productType() == ProductType.COMPONENT && !reqDto.compositions().isEmpty()) {
+            throw new ServiceException(ProductErrorCode.COMPONENT_NOT_HAVE_COMPOSITION);
+        }
+    }
+
+
+    // ===== 헬퍼 메서드 ====
+
+    private Category getCategory(Long id) {
+        return categoryRepository.findById(id)
+            .orElseThrow(() -> new ServiceException(CategoryErrorCode.NOT_FOUND_CATEGORY));
+    }
+}

--- a/src/main/java/com/fittura/domain/product/product/service/ProductService.java
+++ b/src/main/java/com/fittura/domain/product/product/service/ProductService.java
@@ -42,7 +42,7 @@ public class ProductService {
 
     private void validateCategory(Category category) {
         if (category.isArchived()) {
-            throw new ServiceException(CategoryErrorCode.NOT_FOUND_CATEGORY);
+            throw new ServiceException(CategoryErrorCode.ARCHIVED_CATEGORY);
         }
 
         if (!category.isLeaf()) {

--- a/src/main/java/com/fittura/domain/product/sku/constant/AttributeKey.java
+++ b/src/main/java/com/fittura/domain/product/sku/constant/AttributeKey.java
@@ -1,4 +1,4 @@
-package com.fittura.domain.product.constant;
+package com.fittura.domain.product.sku.constant;
 
 public enum AttributeKey {
     WIDTH,

--- a/src/main/java/com/fittura/domain/product/sku/constant/SkuStatus.java
+++ b/src/main/java/com/fittura/domain/product/sku/constant/SkuStatus.java
@@ -1,4 +1,4 @@
-package com.fittura.domain.product.constant;
+package com.fittura.domain.product.sku.constant;
 
 public enum SkuStatus {
     ACTIVE,

--- a/src/main/java/com/fittura/domain/product/sku/dto/request/CompositionCreateReqDto.java
+++ b/src/main/java/com/fittura/domain/product/sku/dto/request/CompositionCreateReqDto.java
@@ -1,0 +1,24 @@
+package com.fittura.domain.product.sku.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
+
+public record CompositionCreateReqDto(
+
+    @Schema(example = "10")
+    @NotNull
+    Long childSkuId,
+
+    @Schema(example = "1")
+    @NotNull
+    @Min(1)
+    Integer quantity,
+
+    @Schema(example = "0")
+    @NotNull
+    @PositiveOrZero
+    Integer sortOrder
+
+) {}

--- a/src/main/java/com/fittura/domain/product/sku/dto/request/CompositionCreateReqDto.java
+++ b/src/main/java/com/fittura/domain/product/sku/dto/request/CompositionCreateReqDto.java
@@ -5,6 +5,7 @@ import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.PositiveOrZero;
 
+@Schema(description = "구성품 생성 요청 DTO")
 public record CompositionCreateReqDto(
 
     @Schema(example = "10")

--- a/src/main/java/com/fittura/domain/product/sku/dto/request/SkuAttributeCreateReqDto.java
+++ b/src/main/java/com/fittura/domain/product/sku/dto/request/SkuAttributeCreateReqDto.java
@@ -6,6 +6,7 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
+@Schema(description = "SKU 요소 생성 요청 DTO")
 public record SkuAttributeCreateReqDto(
 
     @Schema(example = "SIZE")

--- a/src/main/java/com/fittura/domain/product/sku/dto/request/SkuAttributeCreateReqDto.java
+++ b/src/main/java/com/fittura/domain/product/sku/dto/request/SkuAttributeCreateReqDto.java
@@ -1,0 +1,20 @@
+package com.fittura.domain.product.sku.dto.request;
+
+import com.fittura.domain.product.sku.constant.AttributeKey;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record SkuAttributeCreateReqDto(
+
+    @Schema(example = "SIZE")
+    @NotNull
+    AttributeKey attributeKey,
+
+    @Schema(example = "L")
+    @NotBlank
+    @Size(max = 255)
+    String attributeValue
+
+) {}

--- a/src/main/java/com/fittura/domain/product/sku/dto/request/SkuCreateReqDto.java
+++ b/src/main/java/com/fittura/domain/product/sku/dto/request/SkuCreateReqDto.java
@@ -8,6 +8,7 @@ import jakarta.validation.constraints.Size;
 
 import java.util.List;
 
+@Schema(description = "SKU 생성 요청 DTO")
 public record SkuCreateReqDto(
 
     @Schema(example = "100000")
@@ -36,4 +37,8 @@ public record SkuCreateReqDto(
     @Valid
     List<SkuAttributeCreateReqDto> attributes
 
-) {}
+) {
+    public SkuCreateReqDto {
+        attributes = attributes != null ? attributes : List.of();
+    }
+}

--- a/src/main/java/com/fittura/domain/product/sku/dto/request/SkuCreateReqDto.java
+++ b/src/main/java/com/fittura/domain/product/sku/dto/request/SkuCreateReqDto.java
@@ -1,0 +1,39 @@
+package com.fittura.domain.product.sku.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
+import jakarta.validation.constraints.Size;
+
+import java.util.List;
+
+public record SkuCreateReqDto(
+
+    @Schema(example = "100000")
+    @NotNull
+    @PositiveOrZero
+    Long price,
+
+    @Schema(example = "50")
+    @NotNull
+    @PositiveOrZero
+    Integer stockQuantity,
+
+    @Schema(example = "화이트")
+    @Size(max = 50)
+    String color,
+
+    @Schema(example = "원목")
+    @Size(max = 50)
+    String material,
+
+    @Schema(example = "5.5")
+    @NotNull
+    @PositiveOrZero
+    Double weight,
+
+    @Valid
+    List<SkuAttributeCreateReqDto> attributes
+
+) {}

--- a/src/main/java/com/fittura/domain/product/sku/entity/ProductComposition.java
+++ b/src/main/java/com/fittura/domain/product/sku/entity/ProductComposition.java
@@ -1,5 +1,6 @@
-package com.fittura.domain.product.entity;
+package com.fittura.domain.product.sku.entity;
 
+import com.fittura.domain.product.product.entity.Product;
 import com.fittura.global.jpa.entity.BaseEntity;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Min;

--- a/src/main/java/com/fittura/domain/product/sku/entity/ProductComposition.java
+++ b/src/main/java/com/fittura/domain/product/sku/entity/ProductComposition.java
@@ -6,6 +6,8 @@ import jakarta.persistence.*;
 import jakarta.validation.constraints.Min;
 import lombok.NoArgsConstructor;
 
+import java.util.Objects;
+
 import static lombok.AccessLevel.PROTECTED;
 
 @Entity
@@ -27,4 +29,22 @@ public class ProductComposition extends BaseEntity {
 
     @Column(nullable = false)
     private Integer sortOrder = 0;
+
+    public static ProductComposition create(
+        Product parentProduct,
+        ProductSku childSku,
+        Integer quantity,
+        Integer sortOrder
+    ) {
+        Objects.requireNonNull(parentProduct, "parent product must not be null");
+        Objects.requireNonNull(childSku, "child sku must not be null");
+
+        ProductComposition productComposition = new ProductComposition();
+        productComposition.parentProduct = parentProduct;
+        productComposition.childSku = childSku;
+        productComposition.quantity = quantity;
+        productComposition.sortOrder = sortOrder;
+
+        return productComposition;
+    }
 }

--- a/src/main/java/com/fittura/domain/product/sku/entity/ProductComposition.java
+++ b/src/main/java/com/fittura/domain/product/sku/entity/ProductComposition.java
@@ -3,7 +3,6 @@ package com.fittura.domain.product.sku.entity;
 import com.fittura.domain.product.product.entity.Product;
 import com.fittura.global.jpa.entity.BaseEntity;
 import jakarta.persistence.*;
-import jakarta.validation.constraints.Min;
 import lombok.NoArgsConstructor;
 
 import java.util.Objects;
@@ -24,7 +23,6 @@ public class ProductComposition extends BaseEntity {
     private ProductSku childSku;
 
     @Column(nullable = false)
-    @Min(1)
     private Integer quantity = 1;
 
     @Column(nullable = false)
@@ -37,7 +35,10 @@ public class ProductComposition extends BaseEntity {
         Integer sortOrder
     ) {
         Objects.requireNonNull(parentProduct, "parent product must not be null");
-        Objects.requireNonNull(childSku, "child sku must not be null");
+        Objects.requireNonNull(childSku, "child  sku must not be null");
+        if (quantity < 1) {
+            throw new IllegalArgumentException("quantity must be greater than or equal to 1");
+        }
 
         ProductComposition productComposition = new ProductComposition();
         productComposition.parentProduct = parentProduct;

--- a/src/main/java/com/fittura/domain/product/sku/entity/ProductSku.java
+++ b/src/main/java/com/fittura/domain/product/sku/entity/ProductSku.java
@@ -7,6 +7,9 @@ import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import static lombok.AccessLevel.PROTECTED;
 
 @Getter
@@ -41,6 +44,12 @@ public class ProductSku extends BaseEntity {
     @Column(nullable = false)
     private Double weight = 0.0;
 
+    @OneToMany(mappedBy = "sku", cascade = CascadeType.PERSIST)
+    private List<SkuAttribute> attributes = new ArrayList<>();
+
+
+    // ===== 생성 =====
+
     public static ProductSku create(
         Product product,
         Long price,
@@ -60,5 +69,13 @@ public class ProductSku extends BaseEntity {
         productSku.weight = weight;
 
         return productSku;
+    }
+
+    public void addAttribute(SkuAttribute skuAttribute) {
+        attributes.add(skuAttribute);
+    }
+
+    public boolean isArchived() {
+        return status == SkuStatus.ARCHIVED;
     }
 }

--- a/src/main/java/com/fittura/domain/product/sku/entity/ProductSku.java
+++ b/src/main/java/com/fittura/domain/product/sku/entity/ProductSku.java
@@ -9,6 +9,7 @@ import lombok.NoArgsConstructor;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import static lombok.AccessLevel.PROTECTED;
 
@@ -58,6 +59,8 @@ public class ProductSku extends BaseEntity {
         String material,
         Double weight
     ) {
+        Objects.requireNonNull(product, "product must not be null");
+
         ProductSku productSku = new ProductSku();
         productSku.product = product;
         productSku.price = price;

--- a/src/main/java/com/fittura/domain/product/sku/entity/ProductSku.java
+++ b/src/main/java/com/fittura/domain/product/sku/entity/ProductSku.java
@@ -1,6 +1,7 @@
-package com.fittura.domain.product.entity;
+package com.fittura.domain.product.sku.entity;
 
-import com.fittura.domain.product.constant.SkuStatus;
+import com.fittura.domain.product.sku.constant.SkuStatus;
+import com.fittura.domain.product.product.entity.Product;
 import com.fittura.global.jpa.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.NoArgsConstructor;

--- a/src/main/java/com/fittura/domain/product/sku/entity/ProductSku.java
+++ b/src/main/java/com/fittura/domain/product/sku/entity/ProductSku.java
@@ -1,13 +1,15 @@
 package com.fittura.domain.product.sku.entity;
 
-import com.fittura.domain.product.sku.constant.SkuStatus;
 import com.fittura.domain.product.product.entity.Product;
+import com.fittura.domain.product.sku.constant.SkuStatus;
 import com.fittura.global.jpa.entity.BaseEntity;
 import jakarta.persistence.*;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import static lombok.AccessLevel.PROTECTED;
 
+@Getter
 @Entity
 @Table(name = "product_skus")
 @NoArgsConstructor(access = PROTECTED)
@@ -16,9 +18,6 @@ public class ProductSku extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "product_id", nullable = false)
     private Product product;
-
-    @Column(nullable = false, unique = true, length = 100)
-    private String skuCode;
 
     @Column(nullable = false)
     private Long price;
@@ -41,4 +40,25 @@ public class ProductSku extends BaseEntity {
 
     @Column(nullable = false)
     private Double weight = 0.0;
+
+    public static ProductSku create(
+        Product product,
+        Long price,
+        Integer stockQuantity,
+        String color,
+        String material,
+        Double weight
+    ) {
+        ProductSku productSku = new ProductSku();
+        productSku.product = product;
+        productSku.price = price;
+        productSku.stockQuantity = stockQuantity;
+        productSku.status = SkuStatus.ACTIVE;
+
+        productSku.color = color;
+        productSku.material = material;
+        productSku.weight = weight;
+
+        return productSku;
+    }
 }

--- a/src/main/java/com/fittura/domain/product/sku/entity/SkuAttribute.java
+++ b/src/main/java/com/fittura/domain/product/sku/entity/SkuAttribute.java
@@ -1,6 +1,6 @@
-package com.fittura.domain.product.entity;
+package com.fittura.domain.product.sku.entity;
 
-import com.fittura.domain.product.constant.AttributeKey;
+import com.fittura.domain.product.sku.constant.AttributeKey;
 import com.fittura.global.jpa.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.NoArgsConstructor;

--- a/src/main/java/com/fittura/domain/product/sku/entity/SkuAttribute.java
+++ b/src/main/java/com/fittura/domain/product/sku/entity/SkuAttribute.java
@@ -30,4 +30,13 @@ public class SkuAttribute extends BaseEntity {
 
     @Column(nullable = false, length = 255)
     private String attributeValue;
+
+    public static SkuAttribute create(ProductSku sku, AttributeKey key, String value) {
+        SkuAttribute skuAttribute = new SkuAttribute();
+        skuAttribute.sku = sku;
+        skuAttribute.attributeKey = key;
+        skuAttribute.attributeValue = value;
+
+        return skuAttribute;
+    }
 }

--- a/src/main/java/com/fittura/domain/product/sku/entity/SkuAttribute.java
+++ b/src/main/java/com/fittura/domain/product/sku/entity/SkuAttribute.java
@@ -37,6 +37,7 @@ public class SkuAttribute extends BaseEntity {
         skuAttribute.attributeKey = key;
         skuAttribute.attributeValue = value;
 
+        sku.addAttribute(skuAttribute);
         return skuAttribute;
     }
 }

--- a/src/main/java/com/fittura/domain/product/sku/entity/SkuAttribute.java
+++ b/src/main/java/com/fittura/domain/product/sku/entity/SkuAttribute.java
@@ -5,6 +5,8 @@ import com.fittura.global.jpa.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.NoArgsConstructor;
 
+import java.util.Objects;
+
 import static lombok.AccessLevel.PROTECTED;
 
 @Entity
@@ -32,6 +34,8 @@ public class SkuAttribute extends BaseEntity {
     private String attributeValue;
 
     public static SkuAttribute create(ProductSku sku, AttributeKey key, String value) {
+        Objects.requireNonNull(sku, "sku must not be null");
+
         SkuAttribute skuAttribute = new SkuAttribute();
         skuAttribute.sku = sku;
         skuAttribute.attributeKey = key;

--- a/src/main/java/com/fittura/domain/product/sku/repository/ProductCompositionRepository.java
+++ b/src/main/java/com/fittura/domain/product/sku/repository/ProductCompositionRepository.java
@@ -1,0 +1,7 @@
+package com.fittura.domain.product.sku.repository;
+
+import com.fittura.domain.product.sku.entity.ProductComposition;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProductCompositionRepository extends JpaRepository<ProductComposition, Long> {
+}

--- a/src/main/java/com/fittura/domain/product/sku/repository/ProductCompositionRepository.java
+++ b/src/main/java/com/fittura/domain/product/sku/repository/ProductCompositionRepository.java
@@ -2,6 +2,8 @@ package com.fittura.domain.product.sku.repository;
 
 import com.fittura.domain.product.sku.entity.ProductComposition;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface ProductCompositionRepository extends JpaRepository<ProductComposition, Long> {
 }

--- a/src/main/java/com/fittura/domain/product/sku/repository/ProductSkuRepository.java
+++ b/src/main/java/com/fittura/domain/product/sku/repository/ProductSkuRepository.java
@@ -2,7 +2,9 @@ package com.fittura.domain.product.sku.repository;
 
 import com.fittura.domain.product.sku.entity.ProductSku;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface ProductSkuRepository extends JpaRepository<ProductSku, Long> {
 
 }

--- a/src/main/java/com/fittura/domain/product/sku/repository/ProductSkuRepository.java
+++ b/src/main/java/com/fittura/domain/product/sku/repository/ProductSkuRepository.java
@@ -1,0 +1,8 @@
+package com.fittura.domain.product.sku.repository;
+
+import com.fittura.domain.product.sku.entity.ProductSku;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProductSkuRepository extends JpaRepository<ProductSku, Long> {
+
+}

--- a/src/main/java/com/fittura/domain/product/sku/service/SkuService.java
+++ b/src/main/java/com/fittura/domain/product/sku/service/SkuService.java
@@ -52,7 +52,7 @@ public class SkuService {
     public void createCompositions(Product product, List<CompositionCreateReqDto> compositionDtos) {
         for (CompositionCreateReqDto compositionDto : compositionDtos) {
             ProductSku productSku = getProductSku(compositionDto.childSkuId());
-            validProductSkuForComposition(productSku);
+            validateProductSkuForComposition(productSku);
 
             ProductComposition composition = ProductComposition.create(
                 product,
@@ -67,7 +67,7 @@ public class SkuService {
 
     // ===== 유효성 검사 메서드 ====
 
-    private void validProductSkuForComposition(ProductSku productSku) {
+    private void validateProductSkuForComposition(ProductSku productSku) {
         if (productSku.isArchived()) {
             throw new ServiceException(ProductErrorCode.ARCHIVED_SKU);
         }

--- a/src/main/java/com/fittura/domain/product/sku/service/SkuService.java
+++ b/src/main/java/com/fittura/domain/product/sku/service/SkuService.java
@@ -69,7 +69,7 @@ public class SkuService {
 
     private void validProductSkuForComposition(ProductSku productSku) {
         if (productSku.isArchived()) {
-            throw new ServiceException(ProductErrorCode.NOT_FOUND_SKU);
+            throw new ServiceException(ProductErrorCode.ARCHIVED_SKU);
         }
 
         if (productSku.getProduct().isComplete()) {

--- a/src/main/java/com/fittura/domain/product/sku/service/SkuService.java
+++ b/src/main/java/com/fittura/domain/product/sku/service/SkuService.java
@@ -1,0 +1,87 @@
+package com.fittura.domain.product.sku.service;
+
+import com.fittura.domain.product.product.entity.Product;
+import com.fittura.domain.product.product.error.ProductErrorCode;
+import com.fittura.domain.product.sku.dto.request.CompositionCreateReqDto;
+import com.fittura.domain.product.sku.dto.request.SkuAttributeCreateReqDto;
+import com.fittura.domain.product.sku.dto.request.SkuCreateReqDto;
+import com.fittura.domain.product.sku.entity.ProductComposition;
+import com.fittura.domain.product.sku.entity.ProductSku;
+import com.fittura.domain.product.sku.entity.SkuAttribute;
+import com.fittura.domain.product.sku.repository.ProductCompositionRepository;
+import com.fittura.domain.product.sku.repository.ProductSkuRepository;
+import com.fittura.global.exception.ServiceException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class SkuService {
+
+    private final ProductSkuRepository productSkuRepository;
+    private final ProductCompositionRepository compositionRepository;
+
+    public void createSkus(Product product, List<SkuCreateReqDto> skuDtos) {
+        for (SkuCreateReqDto skuDto : skuDtos) {
+            ProductSku productSku = ProductSku.create(
+                product,
+                skuDto.price(),
+                skuDto.stockQuantity(),
+                skuDto.color(),
+                skuDto.material(),
+                skuDto.weight()
+            );
+
+            createAttributes(productSku, skuDto.attributes());
+            productSkuRepository.save(productSku);
+        }
+    }
+
+    private void createAttributes(ProductSku productSku, List<SkuAttributeCreateReqDto> attributesDtos) {
+        for (SkuAttributeCreateReqDto skuAttributeDto : attributesDtos) {
+            SkuAttribute.create(
+                productSku,
+                skuAttributeDto.attributeKey(),
+                skuAttributeDto.attributeValue()
+            );
+        }
+    }
+
+    public void createCompositions(Product product, List<CompositionCreateReqDto> compositionDtos) {
+        for (CompositionCreateReqDto compositionDto : compositionDtos) {
+            ProductSku productSku = getProductSku(compositionDto.childSkuId());
+            validProductSkuForComposition(productSku);
+
+            ProductComposition composition = ProductComposition.create(
+                product,
+                productSku,
+                compositionDto.quantity(),
+                compositionDto.sortOrder()
+            );
+            compositionRepository.save(composition);
+        }
+    }
+
+
+    // ===== 유효성 검사 메서드 ====
+
+    private void validProductSkuForComposition(ProductSku productSku) {
+        if (productSku.isArchived()) {
+            throw new ServiceException(ProductErrorCode.NOT_FOUND_SKU);
+        }
+
+        if (productSku.getProduct().isComplete()) {
+            throw new ServiceException(ProductErrorCode.CHILD_SKU_ONLY_COMPONENT);
+        }
+    }
+
+
+    // ===== 헬퍼 메서드 ====
+
+    public ProductSku getProductSku(Long productSkuId) {
+        return productSkuRepository.findById(productSkuId)
+            .orElseThrow(() -> new ServiceException(ProductErrorCode.NOT_FOUND_SKU));
+    }
+}

--- a/src/test/java/com/fittura/domain/category/service/CategoryServiceTest.java
+++ b/src/test/java/com/fittura/domain/category/service/CategoryServiceTest.java
@@ -67,7 +67,8 @@ class CategoryServiceTest {
         // when & then
         assertThatThrownBy(() -> categoryService.getCategoryById(1L))
             .isInstanceOf(ServiceException.class)
-            .hasMessage(CategoryErrorCode.NOT_FOUND_CATEGORY.getMessage());
+            .extracting(e -> ((ServiceException) e).getErrorCode())
+            .isEqualTo(CategoryErrorCode.NOT_FOUND_CATEGORY);
 
         verify(categoryRepository).findById(1L);
     }
@@ -129,7 +130,8 @@ class CategoryServiceTest {
         // when & then
         assertThatThrownBy(() -> categoryService.createCategory(reqDto))
             .isInstanceOf(ServiceException.class)
-            .hasMessage(CategoryErrorCode.NOT_FOUND_PARENT_CATEGORY.getMessage());
+            .extracting(e -> ((ServiceException) e).getErrorCode())
+            .isEqualTo(CategoryErrorCode.NOT_FOUND_PARENT_CATEGORY);
 
         verify(categoryRepository).findById(1L);
     }
@@ -194,7 +196,8 @@ class CategoryServiceTest {
         // when & then
         assertThatThrownBy(() -> categoryService.updateCategory(1L, reqDto))
             .isInstanceOf(ServiceException.class)
-            .hasMessage(CategoryErrorCode.NOT_FOUND_CATEGORY.getMessage());
+            .extracting(e -> ((ServiceException) e).getErrorCode())
+            .isEqualTo(CategoryErrorCode.NOT_FOUND_CATEGORY);
 
         verify(categoryRepository).findById(1L);
     }
@@ -212,7 +215,8 @@ class CategoryServiceTest {
         // when & then
         assertThatThrownBy(() -> categoryService.updateCategory(1L, reqDto))
             .isInstanceOf(ServiceException.class)
-            .hasMessage(CategoryErrorCode.NOT_FOUND_PARENT_CATEGORY.getMessage());
+            .extracting(e -> ((ServiceException) e).getErrorCode())
+            .isEqualTo(CategoryErrorCode.NOT_FOUND_PARENT_CATEGORY);
 
         verify(categoryRepository).findById(1L);
         verify(categoryRepository).findById(2L);

--- a/src/test/java/com/fittura/domain/product/product/controller/AdminProductControllerV1Test.java
+++ b/src/test/java/com/fittura/domain/product/product/controller/AdminProductControllerV1Test.java
@@ -10,6 +10,7 @@ import com.fittura.domain.product.product.error.ProductErrorCode;
 import com.fittura.domain.product.product.repository.ProductRepository;
 import com.fittura.domain.product.product.support.ProductFixture;
 import com.fittura.domain.product.sku.entity.ProductSku;
+import com.fittura.domain.product.sku.repository.ProductCompositionRepository;
 import com.fittura.domain.product.sku.repository.ProductSkuRepository;
 import com.fittura.domain.product.sku.support.ProductSkuFixture;
 import com.fittura.global.IntegrationTestBase;
@@ -22,6 +23,7 @@ import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -41,6 +43,9 @@ class AdminProductControllerV1Test extends IntegrationTestBase {
     @Autowired
     private ProductSkuRepository productSkuRepository;
 
+    @Autowired
+    private ProductCompositionRepository compositionRepository;
+
     private static final String PRODUCT_ADMIN_URL = "/api/admin/v1/products";
 
 
@@ -58,6 +63,10 @@ class AdminProductControllerV1Test extends IntegrationTestBase {
         ProductSku childSku = productSkuRepository.save(
             ProductSku.create(componentProduct, 5000L, 100, "White", "Wood", 1.5)
         );
+
+        long productCountBefore = productRepository.count();
+        long skuCountBefore = productSkuRepository.count();
+        long compositionCountBefore = compositionRepository.count();
 
         String reqBody = """
             {
@@ -97,6 +106,10 @@ class AdminProductControllerV1Test extends IntegrationTestBase {
             .andExpect(jsonPath("$.code").value("S201-01"))
             .andExpect(jsonPath("$.message").value("제품이 생성되었습니다."))
             .andExpect(jsonPath("$.data").isNumber());
+
+        assertThat(productRepository.count()).isEqualTo(productCountBefore + 1);
+        assertThat(productSkuRepository.count()).isEqualTo(skuCountBefore + 1);
+        assertThat(compositionRepository.count()).isEqualTo(compositionCountBefore + 1);
     }
 
     @Test
@@ -104,6 +117,10 @@ class AdminProductControllerV1Test extends IntegrationTestBase {
     void createComponentSuccess() throws Exception {
         // given
         Category category = categoryRepository.save(CategoryFixture.rootActive());
+
+        long productCountBefore = productRepository.count();
+        long skuCountBefore = productSkuRepository.count();
+        long compositionCountBefore = compositionRepository.count();
 
         String reqBody = """
             {
@@ -139,6 +156,10 @@ class AdminProductControllerV1Test extends IntegrationTestBase {
             .andExpect(jsonPath("$.code").value("S201-01"))
             .andExpect(jsonPath("$.message").value("제품이 생성되었습니다."))
             .andExpect(jsonPath("$.data").isNumber());
+
+        assertThat(productRepository.count()).isEqualTo(productCountBefore + 1);
+        assertThat(productSkuRepository.count()).isEqualTo(skuCountBefore + 1);
+        assertThat(compositionRepository.count()).isEqualTo(compositionCountBefore);
     }
 
     @WithMockUser(roles = "USER")

--- a/src/test/java/com/fittura/domain/product/product/controller/AdminProductControllerV1Test.java
+++ b/src/test/java/com/fittura/domain/product/product/controller/AdminProductControllerV1Test.java
@@ -1,0 +1,294 @@
+package com.fittura.domain.product.product.controller;
+
+import com.fittura.domain.category.entity.Category;
+import com.fittura.domain.category.error.CategoryErrorCode;
+import com.fittura.domain.category.repository.CategoryRepository;
+import com.fittura.domain.category.support.CategoryFixture;
+import com.fittura.domain.product.product.constant.ProductType;
+import com.fittura.domain.product.product.entity.Product;
+import com.fittura.domain.product.product.error.ProductErrorCode;
+import com.fittura.domain.product.product.repository.ProductRepository;
+import com.fittura.domain.product.product.support.ProductFixture;
+import com.fittura.domain.product.sku.entity.ProductSku;
+import com.fittura.domain.product.sku.repository.ProductSkuRepository;
+import com.fittura.domain.product.sku.support.ProductSkuFixture;
+import com.fittura.global.IntegrationTestBase;
+import com.fittura.global.error.CommonErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WithMockUser(roles = "ADMIN")
+class AdminProductControllerV1Test extends IntegrationTestBase {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private CategoryRepository categoryRepository;
+
+    @Autowired
+    private ProductRepository productRepository;
+
+    @Autowired
+    private ProductSkuRepository productSkuRepository;
+
+    private static final String PRODUCT_ADMIN_URL = "/api/admin/v1/products";
+
+
+    // ========== 상품 생성 ==========
+
+    @Test
+    @DisplayName("완제품 생성 성공")
+    void createCompleteSuccess() throws Exception {
+        // given
+        Category category = categoryRepository.save(CategoryFixture.rootActive());
+
+        Product componentProduct = productRepository.save(
+            Product.create(category, "Chair Leg", null, ProductType.COMPONENT, 5000L)
+        );
+        ProductSku childSku = productSkuRepository.save(
+            ProductSku.create(componentProduct, 5000L, 100, "White", "Wood", 1.5)
+        );
+
+        String reqBody = """
+            {
+                "categoryId": %d,
+                "name": "A Desk",
+                "productType": "COMPLETE",
+                "basePrice": 100000,
+                "skus": [{
+                    "price": 90000,
+                    "stockQuantity": 50,
+                    "color": "White",
+                    "material": "Wood",
+                    "weight": 10.5,
+                    "attributes": []
+                }],
+                "compositions": [{
+                    "childSkuId": %d,
+                    "quantity": 4,
+                    "sortOrder": 0
+                }]
+            }
+        """.formatted(category.getId(), childSku.getId());
+
+        // when
+        ResultActions resultActions = mockMvc
+            .perform(post(PRODUCT_ADMIN_URL)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(reqBody)
+            )
+            .andDo(print());
+
+        // then
+        resultActions
+            .andExpect(handler().handlerType(AdminProductControllerV1.class))
+            .andExpect(handler().methodName("createProduct"))
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.code").value("S201-01"))
+            .andExpect(jsonPath("$.message").value("제품이 생성되었습니다."))
+            .andExpect(jsonPath("$.data").isNumber());
+    }
+
+    @Test
+    @DisplayName("단품 생성 성공")
+    void createComponentSuccess() throws Exception {
+        // given
+        Category category = categoryRepository.save(CategoryFixture.rootActive());
+
+        String reqBody = """
+            {
+                "categoryId": %d,
+                "name": "Chair Leg",
+                "productType": "COMPONENT",
+                "basePrice": 5000,
+                "skus": [{
+                    "price": 4500,
+                    "stockQuantity": 100,
+                    "color": "White",
+                    "material": "Wood",
+                    "weight": 2.0,
+                    "attributes": []
+                }],
+                "compositions": []
+            }
+        """.formatted(category.getId());
+
+        // when
+        ResultActions resultActions = mockMvc
+            .perform(post(PRODUCT_ADMIN_URL)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(reqBody)
+            )
+            .andDo(print());
+
+        // then
+        resultActions
+            .andExpect(handler().handlerType(AdminProductControllerV1.class))
+            .andExpect(handler().methodName("createProduct"))
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.code").value("S201-01"))
+            .andExpect(jsonPath("$.message").value("제품이 생성되었습니다."))
+            .andExpect(jsonPath("$.data").isNumber());
+    }
+
+    @WithMockUser(roles = "USER")
+    @Test
+    @DisplayName("상품 생성 실패 - 관리자 아닌 경우")
+    void createForbidden() throws Exception {
+        // given
+        String reqBody = """
+            {
+                "categoryId": 1,
+                "name": "A Desk",
+                "productType": "COMPLETE",
+                "basePrice": 100000,
+                "skus": [{"price": 90000, "stockQuantity": 50, "weight": 10.5, "attributes": []}],
+                "compositions": []
+            }
+        """;
+
+        // when & then
+        mockMvc.perform(post(PRODUCT_ADMIN_URL)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(reqBody)
+            )
+            .andDo(print())
+            .andExpect(status().isForbidden())
+            .andExpect(jsonPath("$.code").value(CommonErrorCode.FORBIDDEN.getCode()))
+            .andExpect(jsonPath("$.message").value(CommonErrorCode.FORBIDDEN.getMessage()));
+    }
+
+    @Test
+    @DisplayName("상품 생성 실패 - validation 오류 (skus 비어있음)")
+    void createFail_validationError() throws Exception {
+        // given - skus는 @Size(min=1) 제약이 있으므로 빈 배열은 실패
+        String reqBody = """
+            {
+                "categoryId": 1,
+                "name": "A Desk",
+                "productType": "COMPLETE",
+                "basePrice": 100000,
+                "skus": [],
+                "compositions": []
+            }
+        """;
+
+        // when & then
+        mockMvc.perform(post(PRODUCT_ADMIN_URL)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(reqBody)
+            )
+            .andDo(print())
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.code").value(CommonErrorCode.VALIDATION_ERROR.getCode()));
+    }
+
+    @Test
+    @DisplayName("상품 생성 실패 - 완제품에 compositions 없음")
+    void createFail_completeMissingCompositions() throws Exception {
+        // given
+        Category category = categoryRepository.save(CategoryFixture.rootActive());
+
+        String reqBody = """
+            {
+                "categoryId": %d,
+                "name": "A Desk",
+                "productType": "COMPLETE",
+                "basePrice": 100000,
+                "skus": [{
+                    "price": 90000,
+                    "stockQuantity": 50,
+                    "weight": 10.5,
+                    "attributes": []
+                }],
+                "compositions": []
+            }
+        """.formatted(category.getId());
+
+        // when & then
+        mockMvc.perform(post(PRODUCT_ADMIN_URL)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(reqBody)
+            )
+            .andDo(print())
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.code").value(ProductErrorCode.COMPLETE_HAVE_COMPOSITIONS.getCode()))
+            .andExpect(jsonPath("$.message").value(ProductErrorCode.COMPLETE_HAVE_COMPOSITIONS.getMessage()));
+    }
+
+    @Test
+    @DisplayName("상품 생성 실패 - 카테고리 없음")
+    void createFail_categoryNotFound() throws Exception {
+        // given
+        String reqBody = """
+            {
+                "categoryId": 9999,
+                "name": "Chair Leg",
+                "productType": "COMPONENT",
+                "basePrice": 5000,
+                "skus": [{
+                    "price": 4500,
+                    "stockQuantity": 100,
+                    "weight": 2.0,
+                    "attributes": []
+                }],
+                "compositions": []
+            }
+        """;
+
+        // when & then
+        mockMvc.perform(post(PRODUCT_ADMIN_URL)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(reqBody)
+            )
+            .andDo(print())
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.code").value(CategoryErrorCode.NOT_FOUND_CATEGORY.getCode()))
+            .andExpect(jsonPath("$.message").value(CategoryErrorCode.NOT_FOUND_CATEGORY.getMessage()));
+    }
+
+    @Test
+    @DisplayName("완제품 생성 실패 - 구성품으로 완제품 SKU 등록")
+    void createCompleteFail_childSkuIsComplete() throws Exception {
+        // given
+        Category category = categoryRepository.save(CategoryFixture.rootActive());
+        Product completeProduct = productRepository.save(ProductFixture.complete(category, "기존 완제품", 100000L));
+        ProductSku completeSku = productSkuRepository.save(ProductSkuFixture.sku(completeProduct, 10000L, 100));
+
+        String reqBody = """
+            {
+                "categoryId": %d,
+                "name": "A Desk",
+                "productType": "COMPLETE",
+                "basePrice": 100000,
+                "skus": [{
+                    "price": 4500,
+                    "stockQuantity": 100,
+                    "weight": 2.0,
+                    "attributes": []
+                }],
+                "compositions": [
+                    { "childSkuId": %d, "quantity": 1, "sortOrder": 0 }
+                ]
+            }
+        """.formatted(category.getId(), completeSku.getId());
+
+        mockMvc.perform(post(PRODUCT_ADMIN_URL)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(reqBody)
+            )
+            .andDo(print())
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.code").value(ProductErrorCode.CHILD_SKU_ONLY_COMPONENT.getCode()));
+    }
+}

--- a/src/test/java/com/fittura/domain/product/product/entity/ProductTest.java
+++ b/src/test/java/com/fittura/domain/product/product/entity/ProductTest.java
@@ -1,0 +1,27 @@
+package com.fittura.domain.product.product.entity;
+
+import com.fittura.domain.product.product.constant.ProductStatus;
+import com.fittura.domain.product.product.constant.ProductType;
+import com.fittura.domain.product.product.support.ProductFixture;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ProductTest {
+
+    // ========== 제품 생성 ==========
+
+    @Test
+    @DisplayName("제품 생성 성공")
+    void createProduct() {
+        // when
+        Product product = ProductFixture.complete("완제품", 10000L);
+
+        // then
+        assertThat(product.getName()).isEqualTo("완제품");
+        assertThat(product.getProductType()).isEqualTo(ProductType.COMPLETE);
+        assertThat(product.getBasePrice()).isEqualTo(10000L);
+        assertThat(product.getStatus()).isEqualTo(ProductStatus.DISABLED);
+    }
+}

--- a/src/test/java/com/fittura/domain/product/product/service/ProductServiceTest.java
+++ b/src/test/java/com/fittura/domain/product/product/service/ProductServiceTest.java
@@ -1,0 +1,143 @@
+package com.fittura.domain.product.product.service;
+
+import com.fittura.domain.category.constant.CategoryStatus;
+import com.fittura.domain.category.entity.Category;
+import com.fittura.domain.category.repository.CategoryRepository;
+import com.fittura.domain.category.support.CategoryFixture;
+import com.fittura.domain.product.product.constant.ProductType;
+import com.fittura.domain.product.product.dto.request.ProductCreateReqDto;
+import com.fittura.domain.product.product.repository.ProductRepository;
+import com.fittura.domain.product.sku.dto.request.CompositionCreateReqDto;
+import com.fittura.domain.product.sku.dto.request.SkuCreateReqDto;
+import com.fittura.global.exception.ServiceException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class ProductServiceTest {
+
+    @Mock
+    private ProductRepository productRepository;
+
+    @Mock
+    private CategoryRepository categoryRepository;
+
+    @InjectMocks
+    private ProductService productService;
+
+
+    // ========== 상품 생성 ==========
+
+    @Test
+    @DisplayName("상품 생성 실패 - 카테고리 없음")
+    void createFail_categoryNotFound() {
+        // given
+        ProductCreateReqDto reqDto = new ProductCreateReqDto(
+            99L, "A Desk", null, ProductType.COMPLETE, 100000L,
+            List.of(skuDto()),
+            List.of(compositionDto())
+        );
+
+        given(categoryRepository.findById(99L)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> productService.createProduct(reqDto))
+            .isInstanceOf(ServiceException.class);
+    }
+
+    @Test
+    @DisplayName("상품 생성 실패 - ARCHIVED 카테고리")
+    void createFail_categoryArchived() {
+        // given
+        Category archived = CategoryFixture.rootActive();
+        ReflectionTestUtils.setField(archived, "status", CategoryStatus.ARCHIVED);
+
+        ProductCreateReqDto reqDto = new ProductCreateReqDto(
+            1L, "A Desk", null, ProductType.COMPLETE, 100000L,
+            List.of(skuDto()),
+            List.of(compositionDto())
+        );
+
+        given(categoryRepository.findById(1L)).willReturn(Optional.of(archived));
+
+        // when & then
+        assertThatThrownBy(() -> productService.createProduct(reqDto))
+            .isInstanceOf(ServiceException.class);
+    }
+
+    @Test
+    @DisplayName("상품 생성 실패 - 리프 카테고리가 아님")
+    void createFail_categoryNotLeaf() {
+        // given
+        Category parent = CategoryFixture.rootActive();
+        CategoryFixture.childActive(parent); // parent에 자식 추가 → isLeaf() == false
+
+        ProductCreateReqDto reqDto = new ProductCreateReqDto(
+            1L, "A Desk", null, ProductType.COMPLETE, 100000L,
+            List.of(skuDto()),
+            List.of(compositionDto())
+        );
+
+        given(categoryRepository.findById(1L)).willReturn(Optional.of(parent));
+
+        // when & then
+        assertThatThrownBy(() -> productService.createProduct(reqDto))
+            .isInstanceOf(ServiceException.class);
+    }
+
+    @Test
+    @DisplayName("완제품 생성 실패 - compositions 없음")
+    void createCompleteFail_noCompositions() {
+        // given
+        ProductCreateReqDto reqDto = new ProductCreateReqDto(
+            1L, "A Desk", null, ProductType.COMPLETE, 100000L,
+            List.of(skuDto()),
+            List.of()
+        );
+
+        given(categoryRepository.findById(1L)).willReturn(Optional.of(CategoryFixture.rootActive()));
+
+        // when & then
+        assertThatThrownBy(() -> productService.createProduct(reqDto))
+            .isInstanceOf(ServiceException.class);
+    }
+
+    @Test
+    @DisplayName("단품 생성 실패 - compositions 있음")
+    void createComponentFail_hasCompositions() {
+        // given
+        ProductCreateReqDto reqDto = new ProductCreateReqDto(
+            1L, "A Desk", null, ProductType.COMPONENT, 100000L,
+            List.of(skuDto()),
+            List.of(compositionDto())  // compositions 있음
+        );
+
+        given(categoryRepository.findById(1L)).willReturn(Optional.of(CategoryFixture.rootActive()));
+
+        // when & then
+        assertThatThrownBy(() -> productService.createProduct(reqDto))
+            .isInstanceOf(ServiceException.class);
+    }
+
+
+    // ========== 핼퍼 메서드 ==========
+
+    private SkuCreateReqDto skuDto() {
+        return new SkuCreateReqDto(10000L, 100, "White", "Wood", 1.5, List.of());
+    }
+
+    private CompositionCreateReqDto compositionDto() {
+        return new CompositionCreateReqDto(1L, 2, 0);
+    }
+}

--- a/src/test/java/com/fittura/domain/product/product/service/ProductServiceTest.java
+++ b/src/test/java/com/fittura/domain/product/product/service/ProductServiceTest.java
@@ -2,10 +2,12 @@ package com.fittura.domain.product.product.service;
 
 import com.fittura.domain.category.constant.CategoryStatus;
 import com.fittura.domain.category.entity.Category;
+import com.fittura.domain.category.error.CategoryErrorCode;
 import com.fittura.domain.category.repository.CategoryRepository;
 import com.fittura.domain.category.support.CategoryFixture;
 import com.fittura.domain.product.product.constant.ProductType;
 import com.fittura.domain.product.product.dto.request.ProductCreateReqDto;
+import com.fittura.domain.product.product.error.ProductErrorCode;
 import com.fittura.domain.product.product.repository.ProductRepository;
 import com.fittura.domain.product.sku.dto.request.CompositionCreateReqDto;
 import com.fittura.domain.product.sku.dto.request.SkuCreateReqDto;
@@ -53,7 +55,9 @@ class ProductServiceTest {
 
         // when & then
         assertThatThrownBy(() -> productService.createProduct(reqDto))
-            .isInstanceOf(ServiceException.class);
+            .isInstanceOf(ServiceException.class)
+            .extracting(e -> ((ServiceException) e).getErrorCode())
+            .isEqualTo(CategoryErrorCode.NOT_FOUND_CATEGORY);
     }
 
     @Test
@@ -73,7 +77,9 @@ class ProductServiceTest {
 
         // when & then
         assertThatThrownBy(() -> productService.createProduct(reqDto))
-            .isInstanceOf(ServiceException.class);
+            .isInstanceOf(ServiceException.class)
+            .extracting(e -> ((ServiceException) e).getErrorCode())
+            .isEqualTo(CategoryErrorCode.ARCHIVED_CATEGORY);
     }
 
     @Test
@@ -93,7 +99,9 @@ class ProductServiceTest {
 
         // when & then
         assertThatThrownBy(() -> productService.createProduct(reqDto))
-            .isInstanceOf(ServiceException.class);
+            .isInstanceOf(ServiceException.class)
+            .extracting(e -> ((ServiceException) e).getErrorCode())
+            .isEqualTo(CategoryErrorCode.NOT_LEAF_CATEGORY);
     }
 
     @Test
@@ -110,7 +118,9 @@ class ProductServiceTest {
 
         // when & then
         assertThatThrownBy(() -> productService.createProduct(reqDto))
-            .isInstanceOf(ServiceException.class);
+            .isInstanceOf(ServiceException.class)
+            .extracting(e -> ((ServiceException) e).getErrorCode())
+            .isEqualTo(ProductErrorCode.COMPLETE_HAVE_COMPOSITIONS);
     }
 
     @Test
@@ -127,7 +137,9 @@ class ProductServiceTest {
 
         // when & then
         assertThatThrownBy(() -> productService.createProduct(reqDto))
-            .isInstanceOf(ServiceException.class);
+            .isInstanceOf(ServiceException.class)
+            .extracting(e -> ((ServiceException) e).getErrorCode())
+            .isEqualTo(ProductErrorCode.COMPONENT_NOT_HAVE_COMPOSITION);
     }
 
 

--- a/src/test/java/com/fittura/domain/product/product/support/ProductFixture.java
+++ b/src/test/java/com/fittura/domain/product/product/support/ProductFixture.java
@@ -15,6 +15,10 @@ public class ProductFixture {
         return Product.create(category, name, "상품 설명", productType, basePrice);
     }
 
+    public static Product complete(Category category, String name, Long basePrice) {
+        return Product.create(category, name, "상품 설명", ProductType.COMPLETE, basePrice);
+    }
+
     public static Product complete(String name, Long basePrice) {
         return product(name, ProductType.COMPLETE, basePrice);
     }

--- a/src/test/java/com/fittura/domain/product/product/support/ProductFixture.java
+++ b/src/test/java/com/fittura/domain/product/product/support/ProductFixture.java
@@ -1,0 +1,25 @@
+package com.fittura.domain.product.product.support;
+
+import com.fittura.domain.category.entity.Category;
+import com.fittura.domain.category.support.CategoryFixture;
+import com.fittura.domain.product.product.constant.ProductType;
+import com.fittura.domain.product.product.entity.Product;
+
+public class ProductFixture {
+
+    private ProductFixture() {}
+
+    public static Product product(String name, ProductType productType, Long basePrice) {
+        Category category = CategoryFixture.rootActive();
+
+        return Product.create(category, name, "상품 설명", productType, basePrice);
+    }
+
+    public static Product complete(String name, Long basePrice) {
+        return product(name, ProductType.COMPLETE, basePrice);
+    }
+
+    public static Product component(String name, Long basePrice) {
+        return product(name, ProductType.COMPONENT, basePrice);
+    }
+}

--- a/src/test/java/com/fittura/domain/product/sku/entity/ProductSkuTest.java
+++ b/src/test/java/com/fittura/domain/product/sku/entity/ProductSkuTest.java
@@ -1,0 +1,27 @@
+package com.fittura.domain.product.sku.entity;
+
+import com.fittura.domain.product.product.entity.Product;
+import com.fittura.domain.product.product.support.ProductFixture;
+import com.fittura.domain.product.sku.constant.SkuStatus;
+import com.fittura.domain.product.sku.support.ProductSkuFixture;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ProductSkuTest {
+
+    // ========== sku 생성 ==========
+
+    @Test
+    @DisplayName("SKU 생성 성공")
+    void createSku() {
+        // when
+        Product product = ProductFixture.complete("완제품", 20000L);
+        ProductSku productSku = ProductSkuFixture.sku(product, 20000L, 20);
+
+        assertThat(productSku.getProduct()).isEqualTo(product);
+        assertThat(productSku.getPrice()).isEqualTo(20000L);
+        assertThat(productSku.getStatus()).isEqualTo(SkuStatus.ACTIVE);
+    }
+}

--- a/src/test/java/com/fittura/domain/product/sku/service/SkuServiceTest.java
+++ b/src/test/java/com/fittura/domain/product/sku/service/SkuServiceTest.java
@@ -1,6 +1,7 @@
 package com.fittura.domain.product.sku.service;
 
 import com.fittura.domain.product.product.entity.Product;
+import com.fittura.domain.product.product.error.ProductErrorCode;
 import com.fittura.domain.product.product.support.ProductFixture;
 import com.fittura.domain.product.sku.constant.SkuStatus;
 import com.fittura.domain.product.sku.dto.request.CompositionCreateReqDto;
@@ -48,7 +49,9 @@ class SkuServiceTest {
 
         // when & then
         assertThatThrownBy(() -> skuService.createCompositions(product, List.of(new CompositionCreateReqDto(99L, 4, 0))))
-            .isInstanceOf(ServiceException.class);
+            .isInstanceOf(ServiceException.class)
+            .extracting(e -> ((ServiceException) e).getErrorCode())
+            .isEqualTo(ProductErrorCode.NOT_FOUND_SKU);
     }
 
     @Test
@@ -63,7 +66,9 @@ class SkuServiceTest {
 
         // when & then
         assertThatThrownBy(() -> skuService.createCompositions(product, List.of(new CompositionCreateReqDto(1L, 4, 0))))
-            .isInstanceOf(ServiceException.class);
+            .isInstanceOf(ServiceException.class)
+            .extracting(e -> ((ServiceException) e).getErrorCode())
+            .isEqualTo(ProductErrorCode.ARCHIVED_SKU);
     }
 
     @Test
@@ -77,6 +82,8 @@ class SkuServiceTest {
 
         // when & then
         assertThatThrownBy(() -> skuService.createCompositions(completeProduct, List.of(new CompositionCreateReqDto(1L, 4, 0))))
-            .isInstanceOf(ServiceException.class);
+            .isInstanceOf(ServiceException.class)
+            .extracting(e -> ((ServiceException) e).getErrorCode())
+            .isEqualTo(ProductErrorCode.CHILD_SKU_ONLY_COMPONENT);
     }
 }

--- a/src/test/java/com/fittura/domain/product/sku/service/SkuServiceTest.java
+++ b/src/test/java/com/fittura/domain/product/sku/service/SkuServiceTest.java
@@ -1,0 +1,82 @@
+package com.fittura.domain.product.sku.service;
+
+import com.fittura.domain.product.product.entity.Product;
+import com.fittura.domain.product.product.support.ProductFixture;
+import com.fittura.domain.product.sku.constant.SkuStatus;
+import com.fittura.domain.product.sku.dto.request.CompositionCreateReqDto;
+import com.fittura.domain.product.sku.entity.ProductSku;
+import com.fittura.domain.product.sku.repository.ProductCompositionRepository;
+import com.fittura.domain.product.sku.repository.ProductSkuRepository;
+import com.fittura.domain.product.sku.support.ProductSkuFixture;
+import com.fittura.global.exception.ServiceException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class SkuServiceTest {
+
+    @Mock
+    private ProductSkuRepository productSkuRepository;
+
+    @Mock
+    private ProductCompositionRepository compositionRepository;
+
+    @InjectMocks
+    private SkuService skuService;
+
+
+    // ========== Composition 생성 ==========
+
+    @Test
+    @DisplayName("Composition 생성 실패 - SKU 없음")
+    void createCompositionsFail_skuNotFound() {
+        // given
+        Product product = ProductFixture.complete("A Desk", 100000L);
+
+        given(productSkuRepository.findById(99L)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> skuService.createCompositions(product, List.of(new CompositionCreateReqDto(99L, 4, 0))))
+            .isInstanceOf(ServiceException.class);
+    }
+
+    @Test
+    @DisplayName("Composition 생성 실패 - ARCHIVED SKU")
+    void createCompositionsFail_skuArchived() {
+        // given
+        Product product = ProductFixture.complete("A Desk", 100000L);
+        ProductSku archivedSku = ProductSkuFixture.skuWithId(1L, ProductFixture.component("Chair Leg", 5000L));
+        ReflectionTestUtils.setField(archivedSku, "status", SkuStatus.ARCHIVED);
+
+        given(productSkuRepository.findById(1L)).willReturn(Optional.of(archivedSku));
+
+        // when & then
+        assertThatThrownBy(() -> skuService.createCompositions(product, List.of(new CompositionCreateReqDto(1L, 4, 0))))
+            .isInstanceOf(ServiceException.class);
+    }
+
+    @Test
+    @DisplayName("Composition 생성 실패 - COMPLETE 상품의 SKU")
+    void createCompositionsFail_skuIsComplete() {
+        // given
+        Product completeProduct = ProductFixture.complete("A Desk", 100000L);
+        ProductSku completeSku = ProductSkuFixture.skuWithId(1L, completeProduct);
+
+        given(productSkuRepository.findById(1L)).willReturn(Optional.of(completeSku));
+
+        // when & then
+        assertThatThrownBy(() -> skuService.createCompositions(completeProduct, List.of(new CompositionCreateReqDto(1L, 4, 0))))
+            .isInstanceOf(ServiceException.class);
+    }
+}

--- a/src/test/java/com/fittura/domain/product/sku/support/ProductCompositionFixture.java
+++ b/src/test/java/com/fittura/domain/product/sku/support/ProductCompositionFixture.java
@@ -1,0 +1,26 @@
+package com.fittura.domain.product.sku.support;
+
+import com.fittura.domain.product.product.entity.Product;
+import com.fittura.domain.product.sku.entity.ProductComposition;
+import com.fittura.domain.product.sku.entity.ProductSku;
+
+public class ProductCompositionFixture {
+
+    private ProductCompositionFixture() {}
+
+    public static ProductComposition composition(
+        Product parentProduct,
+        ProductSku childSku,
+        Integer quantity,
+        Integer sortOrder
+    ) {
+        return ProductComposition.create(parentProduct, childSku, quantity, sortOrder);
+    }
+
+    public static ProductComposition composition(
+        Product parentProduct,
+        ProductSku childSku
+    ) {
+        return composition(parentProduct, childSku, 1, 0);
+    }
+}

--- a/src/test/java/com/fittura/domain/product/sku/support/ProductSkuFixture.java
+++ b/src/test/java/com/fittura/domain/product/sku/support/ProductSkuFixture.java
@@ -1,0 +1,38 @@
+package com.fittura.domain.product.sku.support;
+
+import com.fittura.domain.product.product.entity.Product;
+import com.fittura.domain.product.sku.entity.ProductSku;
+import org.springframework.test.util.ReflectionTestUtils;
+
+public class ProductSkuFixture {
+
+    private ProductSkuFixture() {}
+
+    public static ProductSku sku(Product product, Long price, Integer stock) {
+        return ProductSku.create(
+            product,
+            price,
+            stock,
+            "White",
+            "Wood",
+            1.5
+        );
+    }
+
+    public static ProductSku skuWithOption(Product product, String color, String material) {
+        return ProductSku.create(
+            product,
+            10000L,
+            100,
+            color,
+            material,
+            2.0
+        );
+    }
+
+    public static ProductSku skuWithId(Long id, Product product) {
+        ProductSku sku = sku(product, 20000L, 50);
+        ReflectionTestUtils.setField(sku, "id", id);
+        return sku;
+    }
+}

--- a/src/test/java/com/fittura/domain/product/sku/support/SkuAttributeFixture.java
+++ b/src/test/java/com/fittura/domain/product/sku/support/SkuAttributeFixture.java
@@ -1,0 +1,30 @@
+package com.fittura.domain.product.sku.support;
+
+import com.fittura.domain.product.sku.constant.AttributeKey;
+import com.fittura.domain.product.sku.entity.ProductSku;
+import com.fittura.domain.product.sku.entity.SkuAttribute;
+
+public class SkuAttributeFixture {
+
+    private SkuAttributeFixture() {}
+
+    public static SkuAttribute skuAttribute(ProductSku sku, AttributeKey key, String value) {
+        return SkuAttribute.create(sku, key, value);
+    }
+
+    public static SkuAttribute width(ProductSku sku) {
+        return skuAttribute(sku, AttributeKey.WIDTH, "100");
+    }
+
+    public static SkuAttribute height(ProductSku sku) {
+        return skuAttribute(sku, AttributeKey.HEIGHT, "80");
+    }
+
+    public static SkuAttribute depth(ProductSku sku) {
+        return skuAttribute(sku, AttributeKey.DEPTH, "60");
+    }
+
+    public static SkuAttribute sizeLabel(ProductSku sku) {
+        return skuAttribute(sku, AttributeKey.SIZE_LABEL, "L");
+    }
+}


### PR DESCRIPTION
## 기능 설명
상품 등록 기능 추가

## 주요 사항
- 추후 관리를 위해 product(상품), sku(재고)로 패키지 분리
- facade로 순환 참조 방지
- products + product_skus +  sku_attributes 동시 등록
- product_type 기준으로 COMPLETE / COMPONENT 분기
- COMPLETE 타입이면 product_compositions 함께 등록
- 카테고리 에러코드 C -> CT로 변경 (공통애러코드와 분리 위함)

## 관련 이슈
Closes #58 