### PR TITLE
[fix] Order 도메인 트랜잭션 롤백 검증 테스트 보강

### DIFF
--- a/src/main/java/com/fittura/domain/order/facade/OrderFacade.java
+++ b/src/main/java/com/fittura/domain/order/facade/OrderFacade.java
@@ -20,9 +20,10 @@ public class OrderFacade {
 
     @Transactional
     public Long createOrder(Long memberId, OrderCreateReqDto reqDto) {
-        Order order = orderService.createOrder(memberId, reqDto);
-
         List<CartItem> cartItems = cartService.getItemsByIdAndMember(reqDto.cartItems(), memberId);
+        orderService.validateCartItems(cartItems);
+
+        Order order = orderService.createOrder(memberId, reqDto);
         for(CartItem cartItem : cartItems) {
             orderService.createOrderItem(cartItem, order);
         }

--- a/src/main/java/com/fittura/domain/order/order/error/OrderErrorCode.java
+++ b/src/main/java/com/fittura/domain/order/order/error/OrderErrorCode.java
@@ -13,8 +13,9 @@ public enum OrderErrorCode implements ErrorCode {
     QUANTITY_MUST_BE_POSITIVE(HttpStatus.BAD_REQUEST, "OR400-01", "수량은 1개 이상 선택해야 합니다."),
     QUANTITY_EXCEEDED(HttpStatus.BAD_REQUEST, "OR400-02", "수량은 999개 이하 선택해야 합니다."),
     AMOUNT_MUST_BE_POSITIVE(HttpStatus.BAD_REQUEST, "OR400-03", "금액은 0원 이상이어야 합니다."),
-    SKU_MUST_ACTIVE(HttpStatus.BAD_REQUEST, "OR400-04", "판매중인 상품이 아닙니다."),
-    STOCK_NOT_VALID(HttpStatus.BAD_REQUEST, "OR400-05" , "재고가 부족합니다." );
+    CART_ITEMS_NOT_VALID(HttpStatus.BAD_REQUEST, "OR400-04" , "상품의 상태를 확인해주세요."),
+    SKU_MUST_ACTIVE(HttpStatus.BAD_REQUEST, "OR400-05", "판매중인 상품이 아닙니다."),
+    STOCK_NOT_VALID(HttpStatus.BAD_REQUEST, "OR400-06" , "재고가 부족합니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/fittura/domain/order/order/service/OrderService.java
+++ b/src/main/java/com/fittura/domain/order/order/service/OrderService.java
@@ -4,16 +4,20 @@ import com.fittura.domain.order.cart.entity.CartItem;
 import com.fittura.domain.order.order.dto.request.AddressCreateReqDto;
 import com.fittura.domain.order.order.dto.request.OrderCreateReqDto;
 import com.fittura.domain.order.order.entity.Order;
-import com.fittura.domain.order.order.entity.OrderItem;
 import com.fittura.domain.order.order.entity.OrderAddress;
+import com.fittura.domain.order.order.entity.OrderItem;
 import com.fittura.domain.order.order.error.OrderErrorCode;
+import com.fittura.domain.order.order.repository.OrderAddressRepository;
 import com.fittura.domain.order.order.repository.OrderItemRepository;
 import com.fittura.domain.order.order.repository.OrderRepository;
-import com.fittura.domain.order.order.repository.OrderAddressRepository;
 import com.fittura.domain.product.sku.entity.ProductSku;
+import com.fittura.global.error.ItemError;
 import com.fittura.global.exception.ServiceException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -42,8 +46,6 @@ public class OrderService {
 
     public void createOrderItem(CartItem cartItem, Order order) {
         ProductSku sku = cartItem.getProductSku();
-        validateSku(cartItem, sku);
-
         OrderItem orderItem = OrderItem.create(order, sku, cartItem.getQuantity());
         sku.reserveQuantity(cartItem.getQuantity());
         orderItemRepository.save(orderItem);
@@ -61,14 +63,25 @@ public class OrderService {
         addressRepository.save(orderAddress);
     }
 
-    private void validateSku(CartItem cartItem, ProductSku sku) {
-        String productName = sku.getProduct().getName() + "(" + sku.getSkuIdentifier() + ")";
 
-        if (!sku.isActive()) {
-            throw new ServiceException(OrderErrorCode.SKU_MUST_ACTIVE, productName);
+    // ========== 유효성 검사 ==========
+
+    public void validateCartItems(List<CartItem> cartItems) {
+        List<ItemError> errors = new ArrayList<>();
+
+        for (CartItem cartItem : cartItems) {
+            ProductSku sku = cartItem.getProductSku();
+            String productName = sku.getProduct().getName() + "(" + sku.getSkuIdentifier() + ")";
+
+            if (!sku.isActive()) {
+                errors.add(ItemError.of(productName, OrderErrorCode.SKU_MUST_ACTIVE));
+            } else if (!sku.isStockValid(cartItem.getQuantity())) {
+                errors.add(ItemError.of(productName, OrderErrorCode.STOCK_NOT_VALID));
+            }
         }
-        if (!sku.isStockValid(cartItem.getQuantity())) {
-            throw new ServiceException(OrderErrorCode.STOCK_NOT_VALID);
+
+        if (!errors.isEmpty()) {
+            throw new ServiceException(OrderErrorCode.CART_ITEMS_NOT_VALID, errors);
         }
     }
 }

--- a/src/main/java/com/fittura/global/error/ItemError.java
+++ b/src/main/java/com/fittura/global/error/ItemError.java
@@ -1,0 +1,8 @@
+package com.fittura.global.error;
+
+public record ItemError(String target, String code, String message) {
+    // 검증 실패 항목과 실패 사유를 묶어 ItemError 생성
+    public static ItemError of(String target, ErrorCode errorCode) {
+        return new ItemError(target, errorCode.getCode(), errorCode.getMessage());
+    }
+}

--- a/src/main/java/com/fittura/global/error/ValidationError.java
+++ b/src/main/java/com/fittura/global/error/ValidationError.java
@@ -3,10 +3,7 @@ package com.fittura.global.error;
 import jakarta.validation.ConstraintViolation;
 import org.springframework.validation.FieldError;
 
-public record ValidationError(
-        String field,
-        String message
-) {
+public record ValidationError(String field, String message) {
     // @Validated 에서 발생한 ConstraintViolation 을 ValidationError 로 변환
     public static ValidationError from(ConstraintViolation<?> violation) {
         String field = violation.getPropertyPath().toString();

--- a/src/main/java/com/fittura/global/exceptionhandler/GlobalExceptionHandler.java
+++ b/src/main/java/com/fittura/global/exceptionhandler/GlobalExceptionHandler.java
@@ -120,7 +120,6 @@ public class GlobalExceptionHandler {
     public ResponseEntity<RsData<Map<String, String>>> handle(Exception e) {
         String traceId = UUID.randomUUID().toString();
 
-        // traceId를 포함하여 에러 로그 상세히 기록
         log.error("Unhandled server error occurred. traceId={}", traceId, e);
 
         // 클라이언트에게 traceId와 간단한 메시지만 전달

--- a/src/test/java/com/fittura/domain/order/cart/controller/CartControllerV1Test.java
+++ b/src/test/java/com/fittura/domain/order/cart/controller/CartControllerV1Test.java
@@ -15,6 +15,7 @@ import com.fittura.domain.product.product.repository.ProductRepository;
 import com.fittura.domain.product.product.support.ProductFixture;
 import com.fittura.domain.product.sku.entity.ProductSku;
 import com.fittura.domain.product.sku.repository.ProductSkuRepository;
+import com.fittura.domain.product.sku.support.ProductSkuFixture;
 import com.fittura.global.IntegrationTestBase;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -350,6 +351,6 @@ class CartControllerV1Test extends IntegrationTestBase {
     private ProductSku savedDefaultSku() {
         Category category = categoryRepository.save(CategoryFixture.rootActive());
         Product product = productRepository.save(ProductFixture.component(category, "A Desk"));
-        return productSkuRepository.save(ProductSku.create(product, 10000L, 100, "White", "Wood"));
+        return productSkuRepository.save(ProductSkuFixture.sku(product, 10000L, 100));
     }
 }

--- a/src/test/java/com/fittura/domain/order/cart/controller/CartControllerV1Test.java
+++ b/src/test/java/com/fittura/domain/order/cart/controller/CartControllerV1Test.java
@@ -7,6 +7,8 @@ import com.fittura.domain.order.cart.entity.Cart;
 import com.fittura.domain.order.cart.entity.CartItem;
 import com.fittura.domain.order.cart.repository.CartItemRepository;
 import com.fittura.domain.order.cart.repository.CartRepository;
+import com.fittura.domain.order.cart.support.CartFixture;
+import com.fittura.domain.order.cart.support.CartItemFixture;
 import com.fittura.domain.product.product.entity.Product;
 import com.fittura.domain.product.product.error.ProductErrorCode;
 import com.fittura.domain.product.product.repository.ProductRepository;
@@ -80,8 +82,8 @@ class CartControllerV1Test extends IntegrationTestBase {
         Long memberId = 11L;
         ProductSku sku = savedDefaultSku();  // price: 10000
 
-        Cart cart = cartRepository.save(Cart.create(memberId));
-        cartItemRepository.save(CartItem.create(cart, sku, 3));
+        Cart cart = cartRepository.save(CartFixture.cart(memberId));
+        cartItemRepository.save(CartItemFixture.cartItem(cart, sku, 3));
 
         // when & then
         mockMvc.perform(get(CART_URL)
@@ -108,8 +110,8 @@ class CartControllerV1Test extends IntegrationTestBase {
         sku.archive();
         productSkuRepository.save(sku);
 
-        Cart cart = cartRepository.save(Cart.create(memberId));
-        cartItemRepository.save(CartItem.create(cart, sku, 2));
+        Cart cart = cartRepository.save(CartFixture.cart(memberId));
+        cartItemRepository.save(CartItemFixture.cartItem(cart, sku, 2));
 
         // when & then
         mockMvc.perform(get(CART_URL)
@@ -160,8 +162,8 @@ class CartControllerV1Test extends IntegrationTestBase {
         Long memberId = 2L;
         ProductSku sku = savedDefaultSku();
 
-        Cart cart = cartRepository.save(Cart.create(memberId));
-        cartItemRepository.save(CartItem.create(cart, sku, 2));
+        Cart cart = cartRepository.save(CartFixture.cart(memberId));
+        cartItemRepository.save(CartItemFixture.cartItem(cart, sku, 2));
 
         String reqBody = """
                 {
@@ -216,8 +218,8 @@ class CartControllerV1Test extends IntegrationTestBase {
         // given
         Long memberId = 20L;
         ProductSku sku = savedDefaultSku();
-        Cart cart = cartRepository.save(Cart.create(memberId));
-        CartItem cartItem = cartItemRepository.save(CartItem.create(cart, sku, 2));
+        Cart cart = cartRepository.save(CartFixture.cart(memberId));
+        CartItem cartItem = cartItemRepository.save(CartItemFixture.cartItem(cart, sku, 2));
 
         String reqBody = """
                 {
@@ -268,8 +270,8 @@ class CartControllerV1Test extends IntegrationTestBase {
         Long ownerMemberId = 22L;
         Long otherMemberId = 23L;
         ProductSku sku = savedDefaultSku();
-        Cart ownerCart = cartRepository.save(Cart.create(ownerMemberId));
-        CartItem cartItem = cartItemRepository.save(CartItem.create(ownerCart, sku, 2));
+        Cart ownerCart = cartRepository.save(CartFixture.cart(ownerMemberId));
+        CartItem cartItem = cartItemRepository.save(CartItemFixture.cartItem(ownerCart, sku, 2));
 
         String reqBody = """
                 {
@@ -296,8 +298,8 @@ class CartControllerV1Test extends IntegrationTestBase {
         // given
         Long memberId = 30L;
         ProductSku sku = savedDefaultSku();
-        Cart cart = cartRepository.save(Cart.create(memberId));
-        CartItem cartItem = cartItemRepository.save(CartItem.create(cart, sku, 2));
+        Cart cart = cartRepository.save(CartFixture.cart(memberId));
+        CartItem cartItem = cartItemRepository.save(CartItemFixture.cartItem(cart, sku, 2));
 
         // when & then
         mockMvc.perform(delete(CART_URL + "/items/" + cartItem.getId())
@@ -331,8 +333,8 @@ class CartControllerV1Test extends IntegrationTestBase {
         Long ownerMemberId = 32L;
         Long otherMemberId = 33L;
         ProductSku sku = savedDefaultSku();
-        Cart ownerCart = cartRepository.save(Cart.create(ownerMemberId));
-        CartItem cartItem = cartItemRepository.save(CartItem.create(ownerCart, sku, 2));
+        Cart ownerCart = cartRepository.save(CartFixture.cart(ownerMemberId));
+        CartItem cartItem = cartItemRepository.save(CartItemFixture.cartItem(ownerCart, sku, 2));
 
         // when & then
         mockMvc.perform(delete(CART_URL + "/items/" + cartItem.getId())

--- a/src/test/java/com/fittura/domain/order/order/controller/OrderControllerTest.java
+++ b/src/test/java/com/fittura/domain/order/order/controller/OrderControllerTest.java
@@ -252,7 +252,7 @@ class OrderControllerTest extends IntegrationTestBase {
                 .content(reqBody))
             .andDo(print())
             .andExpect(status().isBadRequest())
-            .andExpect(jsonPath("$.code").value(OrderErrorCode.SKU_MUST_ACTIVE.getCode()));
+            .andExpect(jsonPath("$.code").value(OrderErrorCode.CART_ITEMS_NOT_VALID.getCode()));
 
         assertThat(orderRepository.count()).isEqualTo(0);
         assertThat(orderItemRepository.count()).isEqualTo(0);
@@ -293,7 +293,7 @@ class OrderControllerTest extends IntegrationTestBase {
                 .content(reqBody))
             .andDo(print())
             .andExpect(status().isBadRequest())
-            .andExpect(jsonPath("$.code").value(OrderErrorCode.STOCK_NOT_VALID.getCode()));
+            .andExpect(jsonPath("$.code").value(OrderErrorCode.CART_ITEMS_NOT_VALID.getCode()));
 
         assertThat(orderRepository.count()).isEqualTo(0);
         assertThat(orderItemRepository.count()).isEqualTo(0);

--- a/src/test/java/com/fittura/domain/order/order/controller/OrderControllerTest.java
+++ b/src/test/java/com/fittura/domain/order/order/controller/OrderControllerTest.java
@@ -5,9 +5,11 @@ import com.fittura.domain.category.repository.CategoryRepository;
 import com.fittura.domain.category.support.CategoryFixture;
 import com.fittura.domain.order.cart.entity.Cart;
 import com.fittura.domain.order.cart.entity.CartItem;
+import com.fittura.domain.order.cart.error.CartErrorCode;
 import com.fittura.domain.order.cart.repository.CartItemRepository;
 import com.fittura.domain.order.cart.repository.CartRepository;
-import com.fittura.domain.order.cart.error.CartErrorCode;
+import com.fittura.domain.order.cart.support.CartFixture;
+import com.fittura.domain.order.cart.support.CartItemFixture;
 import com.fittura.domain.order.order.error.OrderErrorCode;
 import com.fittura.domain.order.order.repository.OrderAddressRepository;
 import com.fittura.domain.order.order.repository.OrderItemRepository;
@@ -17,6 +19,7 @@ import com.fittura.domain.product.product.repository.ProductRepository;
 import com.fittura.domain.product.product.support.ProductFixture;
 import com.fittura.domain.product.sku.entity.ProductSku;
 import com.fittura.domain.product.sku.repository.ProductSkuRepository;
+import com.fittura.domain.product.sku.support.ProductSkuFixture;
 import com.fittura.global.IntegrationTestBase;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -220,7 +223,7 @@ class OrderControllerTest extends IntegrationTestBase {
     void createOrderFail_skuNotActive() throws Exception {
         // given
         Long memberId = 11L;
-        ProductSku sku = savedDefaultSku();
+        ProductSku sku = savedDefaultSku(10);
         sku.soldOut();
         productSkuRepository.save(sku);
 
@@ -262,12 +265,11 @@ class OrderControllerTest extends IntegrationTestBase {
     void createOrderFail_stockNotValid() throws Exception {
         // given
         Long memberId = 12L;
-        Category category = categoryRepository.save(CategoryFixture.rootActive());
-        Product product = productRepository.save(ProductFixture.component(category, "A Desk"));
-        ProductSku sku = productSkuRepository.save(ProductSku.create(product, 10000L, 2, "White", "Wood"));
+        ProductSku sku = savedDefaultSku(2);
 
-        Cart cart = cartRepository.save(Cart.create(memberId));
-        CartItem cartItem = cartItemRepository.save(CartItem.create(cart, sku, 5));
+
+        Cart cart = cartRepository.save(CartFixture.cart(memberId));
+        CartItem cartItem = cartItemRepository.save(CartItemFixture.cartItem(cart, sku, 5));
 
         String reqBody = """
                 {
@@ -303,8 +305,12 @@ class OrderControllerTest extends IntegrationTestBase {
     // ========== 헬퍼 메서드 ==========
 
     private ProductSku savedDefaultSku() {
+        return savedDefaultSku(100);
+    }
+
+    private ProductSku savedDefaultSku(Integer stock) {
         Category category = categoryRepository.save(CategoryFixture.rootActive());
         Product product = productRepository.save(ProductFixture.component(category, "A Desk"));
-        return productSkuRepository.save(ProductSku.create(product, 10000L, 100, "White", "Wood"));
+        return productSkuRepository.save(ProductSkuFixture.sku(product, 10000L, stock));
     }
 }

--- a/src/test/java/com/fittura/domain/order/order/controller/OrderControllerTest.java
+++ b/src/test/java/com/fittura/domain/order/order/controller/OrderControllerTest.java
@@ -28,6 +28,7 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -252,7 +253,9 @@ class OrderControllerTest extends IntegrationTestBase {
                 .content(reqBody))
             .andDo(print())
             .andExpect(status().isBadRequest())
-            .andExpect(jsonPath("$.code").value(OrderErrorCode.CART_ITEMS_NOT_VALID.getCode()));
+            .andExpect(jsonPath("$.code").value(OrderErrorCode.CART_ITEMS_NOT_VALID.getCode()))
+            .andExpect(jsonPath("$.data.length()").value(1))
+            .andExpect(jsonPath("$.data[0].code").value(OrderErrorCode.SKU_MUST_ACTIVE.getCode()));
 
         assertThat(orderRepository.count()).isEqualTo(0);
         assertThat(orderItemRepository.count()).isEqualTo(0);
@@ -293,12 +296,60 @@ class OrderControllerTest extends IntegrationTestBase {
                 .content(reqBody))
             .andDo(print())
             .andExpect(status().isBadRequest())
-            .andExpect(jsonPath("$.code").value(OrderErrorCode.CART_ITEMS_NOT_VALID.getCode()));
+            .andExpect(jsonPath("$.code").value(OrderErrorCode.CART_ITEMS_NOT_VALID.getCode()))
+            .andExpect(jsonPath("$.data.length()").value(1))
+            .andExpect(jsonPath("$.data[0].code").value(OrderErrorCode.STOCK_NOT_VALID.getCode()));
 
         assertThat(orderRepository.count()).isEqualTo(0);
         assertThat(orderItemRepository.count()).isEqualTo(0);
         assertThat(addressRepository.count()).isEqualTo(0);
         assertThat(cartItemRepository.findById(cartItem.getId())).isPresent();
+    }
+
+    @Test
+    @DisplayName("주문 생성 실패 - 여러 항목이 각각의 사유로 실패")
+    void createOrderFail_multipleInvalidItems() throws Exception {
+        // given
+        Long memberId = 13L;
+        ProductSku soldOutSku = savedDefaultSku(10);
+        soldOutSku.soldOut();
+        productSkuRepository.save(soldOutSku);
+        ProductSku lowStockSku = savedDefaultSku(2);
+
+        Cart cart = cartRepository.save(CartFixture.cart(memberId));
+        CartItem item1 = cartItemRepository.save(CartItemFixture.cartItem(cart, soldOutSku, 1));
+        CartItem item2 = cartItemRepository.save(CartItemFixture.cartItem(cart, lowStockSku, 5));
+
+        String reqBody = """
+            {
+                "cartItems": [%d, %d],
+                "pointUsedAmount": 0,
+                "orderAddress": {
+                    "receiverName": "홍길동",
+                    "phoneNumber": "01012341234",
+                    "zipCode": "12345",
+                    "address": "서울특별시 중구 서소문로 127",
+                    "sido": "서울특별시",
+                    "sigungu": "중구"
+                }
+            }
+            """.formatted(item1.getId(), item2.getId());
+
+        // when & then
+        mockMvc.perform(post(ORDER_URL)
+                .header("Authorization", userBearerToken(memberId))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(reqBody))
+            .andDo(print())
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.code").value(OrderErrorCode.CART_ITEMS_NOT_VALID.getCode()))
+            .andExpect(jsonPath("$.data.length()").value(2))
+            .andExpect(jsonPath("$.data[*].code",
+                containsInAnyOrder(
+                    OrderErrorCode.SKU_MUST_ACTIVE.getCode(),
+                    OrderErrorCode.STOCK_NOT_VALID.getCode())));
+
+        assertThat(orderRepository.count()).isEqualTo(0);
     }
 
 

--- a/src/test/java/com/fittura/domain/order/order/controller/OrderControllerTest.java
+++ b/src/test/java/com/fittura/domain/order/order/controller/OrderControllerTest.java
@@ -74,8 +74,8 @@ class OrderControllerTest extends IntegrationTestBase {
         // given
         Long memberId = 1L;
         ProductSku sku = savedDefaultSku();
-        Cart cart = cartRepository.save(Cart.create(memberId));
-        CartItem cartItem = cartItemRepository.save(CartItem.create(cart, sku, 2));
+        Cart cart = cartRepository.save(CartFixture.cart(memberId));
+        CartItem cartItem = cartItemRepository.save(CartItemFixture.cartItem(cart, sku, 2));
 
         String reqBody = """
                 {
@@ -117,9 +117,9 @@ class OrderControllerTest extends IntegrationTestBase {
         Long memberId = 2L;
         ProductSku sku1 = savedDefaultSku();
         ProductSku sku2 = savedDefaultSku();
-        Cart cart = cartRepository.save(Cart.create(memberId));
-        CartItem cartItem1 = cartItemRepository.save(CartItem.create(cart, sku1, 1));
-        CartItem cartItem2 = cartItemRepository.save(CartItem.create(cart, sku2, 3));
+        Cart cart = cartRepository.save(CartFixture.cart(memberId));
+        CartItem cartItem1 = cartItemRepository.save(CartItemFixture.cartItem(cart, sku1, 1));
+        CartItem cartItem2 = cartItemRepository.save(CartItemFixture.cartItem(cart, sku2, 3));
 
         String reqBody = """
                 {
@@ -156,8 +156,8 @@ class OrderControllerTest extends IntegrationTestBase {
         Long ownerMemberId = 20L;
         Long attackerMemberId = 21L;
         ProductSku sku = savedDefaultSku();
-        Cart ownerCart = cartRepository.save(Cart.create(ownerMemberId));
-        CartItem ownerItem = cartItemRepository.save(CartItem.create(ownerCart, sku, 1));
+        Cart ownerCart = cartRepository.save(CartFixture.cart(ownerMemberId));
+        CartItem ownerItem = cartItemRepository.save(CartItemFixture.cartItem(ownerCart, sku, 1));
 
         String reqBody = """
                 {
@@ -228,8 +228,8 @@ class OrderControllerTest extends IntegrationTestBase {
         sku.soldOut();
         productSkuRepository.save(sku);
 
-        Cart cart = cartRepository.save(Cart.create(memberId));
-        CartItem cartItem = cartItemRepository.save(CartItem.create(cart, sku, 1));
+        Cart cart = cartRepository.save(CartFixture.cart(memberId));
+        CartItem cartItem = cartItemRepository.save(CartItemFixture.cartItem(cart, sku, 1));
 
         String reqBody = """
                 {

--- a/src/test/java/com/fittura/domain/order/order/service/OrderServiceTest.java
+++ b/src/test/java/com/fittura/domain/order/order/service/OrderServiceTest.java
@@ -9,7 +9,6 @@ import com.fittura.domain.order.order.dto.request.OrderCreateReqDto;
 import com.fittura.domain.order.order.entity.Order;
 import com.fittura.domain.order.order.entity.OrderAddress;
 import com.fittura.domain.order.order.entity.OrderItem;
-import com.fittura.domain.order.order.error.OrderErrorCode;
 import com.fittura.domain.order.order.repository.OrderAddressRepository;
 import com.fittura.domain.order.order.repository.OrderItemRepository;
 import com.fittura.domain.order.order.repository.OrderRepository;
@@ -19,7 +18,6 @@ import com.fittura.domain.product.product.entity.Product;
 import com.fittura.domain.product.product.support.ProductFixture;
 import com.fittura.domain.product.sku.entity.ProductSku;
 import com.fittura.domain.product.sku.support.ProductSkuFixture;
-import com.fittura.global.exception.ServiceException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -30,10 +28,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
@@ -109,49 +105,6 @@ class OrderServiceTest {
         // then
         assertThat(sku.getReservedQuantity()).isEqualTo(3);
         verify(itemRepository).save(any(OrderItem.class));
-    }
-
-    @Test
-    @DisplayName("주문 아이템 생성 실패 - 비활성 SKU")
-    void createOrderItemFail_skuNotActive() {
-        // given
-        Long memberId = 1L;
-        Product product = ProductFixture.component("A Desk");
-        ProductSku sku = ProductSkuFixture.sku(product, 20000L, 10);
-        sku.soldOut();
-        Order order = OrderFixture.order(memberId);
-        Cart cart = CartFixture.cart(memberId);
-        CartItem cartItem = CartItemFixture.cartItem(cart, sku, 3);
-
-        // when & then
-        assertThatThrownBy(() -> orderService.createOrderItem(cartItem, order))
-            .isInstanceOf(ServiceException.class)
-            .extracting(e -> ((ServiceException) e).getErrorCode())
-            .isEqualTo(OrderErrorCode.SKU_MUST_ACTIVE);
-
-        assertThat(sku.getReservedQuantity()).isEqualTo(0);
-        verify(itemRepository, never()).save(any(OrderItem.class));
-    }
-
-    @Test
-    @DisplayName("주문 아이템 생성 실패 - 재고 부족")
-    void createOrderItemFail_stockNotValid() {
-        // given
-        Long memberId = 1L;
-        Product product = ProductFixture.component("A Desk");
-        ProductSku sku = ProductSkuFixture.sku(product, 20000L, 2);
-        Cart cart = CartFixture.cart(memberId);
-        CartItem cartItem = CartItemFixture.cartItem(cart, sku, 5);
-        Order order = OrderFixture.order(memberId);
-
-        // when & then
-        assertThatThrownBy(() -> orderService.createOrderItem(cartItem, order))
-            .isInstanceOf(ServiceException.class)
-            .extracting(e -> ((ServiceException) e).getErrorCode())
-            .isEqualTo(OrderErrorCode.STOCK_NOT_VALID);
-
-        assertThat(sku.getReservedQuantity()).isEqualTo(0);
-        verify(itemRepository, never()).save(any(OrderItem.class));
     }
 
 

--- a/src/test/java/com/fittura/domain/product/product/controller/AdminProductControllerV1Test.java
+++ b/src/test/java/com/fittura/domain/product/product/controller/AdminProductControllerV1Test.java
@@ -6,18 +6,17 @@ import com.fittura.domain.category.repository.CategoryRepository;
 import com.fittura.domain.category.support.CategoryFixture;
 import com.fittura.domain.product.product.constant.AttributeKey;
 import com.fittura.domain.product.product.constant.ProductStatus;
-import com.fittura.domain.product.product.constant.ProductType;
-import com.fittura.domain.product.product.entity.Dimension;
 import com.fittura.domain.product.product.entity.Product;
-import com.fittura.domain.product.product.entity.ProductAttribute;
 import com.fittura.domain.product.product.error.ProductErrorCode;
 import com.fittura.domain.product.product.repository.ProductAttributeRepository;
 import com.fittura.domain.product.product.repository.ProductRepository;
+import com.fittura.domain.product.product.support.ProductAttributeFixture;
 import com.fittura.domain.product.product.support.ProductFixture;
 import com.fittura.domain.product.sku.entity.ProductComposition;
 import com.fittura.domain.product.sku.entity.ProductSku;
 import com.fittura.domain.product.sku.repository.CompositionRepository;
 import com.fittura.domain.product.sku.repository.ProductSkuRepository;
+import com.fittura.domain.product.sku.support.ProductCompositionFixture;
 import com.fittura.domain.product.sku.support.ProductSkuFixture;
 import com.fittura.global.IntegrationTestBase;
 import com.fittura.global.error.CommonErrorCode;
@@ -69,15 +68,14 @@ class AdminProductControllerV1Test extends IntegrationTestBase {
     void getProductsSuccess() throws Exception {
         // given
         Category category = categoryRepository.save(CategoryFixture.rootActive());
-        Dimension dimension = Dimension.of(40.5, 150.0, 100.0, 50.0);
 
-        Product activeProduct = Product.create(category, "Active Desk", null, ProductType.COMPONENT, dimension);
+        Product activeProduct = ProductFixture.component(category, "Active Desk");
         activeProduct.activate();
         productRepository.save(activeProduct);
 
-        productRepository.save(Product.create(category, "Disabled Chair", null, ProductType.COMPONENT, dimension));
+        productRepository.save(ProductFixture.component(category, "Disabled Chair"));
 
-        Product discontinuedProduct = Product.create(category, "Discontinued Sofa", null, ProductType.COMPONENT, dimension);
+        Product discontinuedProduct = ProductFixture.component(category, "Discontinued Sofa");
         ReflectionTestUtils.setField(discontinuedProduct, "status", ProductStatus.DISCONTINUED);
         productRepository.save(discontinuedProduct);
 
@@ -94,13 +92,12 @@ class AdminProductControllerV1Test extends IntegrationTestBase {
     void getProducts_statusFilter() throws Exception {
         // given
         Category category = categoryRepository.save(CategoryFixture.rootActive());
-        Dimension dimension = Dimension.of(40.5, 150.0, 100.0, 50.0);
 
-        Product activeProduct = Product.create(category, "Active Desk", null, ProductType.COMPONENT, dimension);
+        Product activeProduct = ProductFixture.component(category, "Active Desk");
         activeProduct.activate();
         productRepository.save(activeProduct);
 
-        productRepository.save(Product.create(category, "Disabled Chair", null, ProductType.COMPONENT, dimension));
+        productRepository.save(ProductFixture.component(category, "Disabled Chair"));
 
         // when & then
         mockMvc.perform(get(PRODUCT_ADMIN_URL).param("statuses", "ACTIVE"))
@@ -115,13 +112,12 @@ class AdminProductControllerV1Test extends IntegrationTestBase {
     void getProducts_includesArchived() throws Exception {
         // given
         Category category = categoryRepository.save(CategoryFixture.rootActive());
-        Dimension dimension = Dimension.of(40.5, 150.0, 100.0, 50.0);
 
-        Product activeProduct = Product.create(category, "Active Desk", null, ProductType.COMPONENT, dimension);
+        Product activeProduct = ProductFixture.component(category, "Active Desk");
         activeProduct.activate();
         productRepository.save(activeProduct);
 
-        Product disabledProduct = Product.create(category, "DISABLED Desk", null, ProductType.COMPONENT, dimension);
+        Product disabledProduct = ProductFixture.component(category, "DISABLED Desk");
         productRepository.save(disabledProduct);
 
         // when & then
@@ -150,11 +146,10 @@ class AdminProductControllerV1Test extends IntegrationTestBase {
     void getProductSuccess() throws Exception {
         // given
         Category category = categoryRepository.save(CategoryFixture.rootActive());
-        Dimension dimension = Dimension.of(40.5, 150.0, 100.0, 50.0);
         Product product = productRepository.save(
-            Product.create(category, "A Desk", "책상입니다.", ProductType.COMPONENT, dimension)
+            ProductFixture.component(category, "A Desk")
         );
-        productSkuRepository.save(ProductSku.create(product, 45000L, 100, "White", "Wood"));
+        productSkuRepository.save(ProductSkuFixture.sku(product, 45000L, 100));
 
         // when & then
         mockMvc.perform(get(PRODUCT_ADMIN_URL + "/" + product.getId()))
@@ -193,13 +188,12 @@ class AdminProductControllerV1Test extends IntegrationTestBase {
     void createCompleteSuccess() throws Exception {
         // given
         Category category = categoryRepository.save(CategoryFixture.rootActive());
-        Dimension dimension = Dimension.of(40.5, 150.0, 100.0, 50.0);
 
         Product componentProduct = productRepository.save(
-            Product.create(category, "Chair Leg", null, ProductType.COMPONENT, dimension)
+            ProductFixture.component(category, "Chair Leg")
         );
         ProductSku childSku = productSkuRepository.save(
-            ProductSku.create(componentProduct, 5000L, 100, "White", "Wood")
+            ProductSkuFixture.sku(componentProduct, 5000L, 100)
         );
 
         long productCountBefore = productRepository.count();
@@ -553,21 +547,20 @@ class AdminProductControllerV1Test extends IntegrationTestBase {
     void updateComponentSuccess() throws Exception {
         // given
         Category category = categoryRepository.save(CategoryFixture.rootActive());
-        Dimension dimension = Dimension.of(40.5, 150.0, 100.0, 50.0);
         Product product = productRepository.save(
-            Product.create(category, "Old Name", "설명", ProductType.COMPONENT, dimension)
+            ProductFixture.component(category, "Old Name")
         );
-        ProductSku sku = productSkuRepository.save(ProductSku.create(product, 45000L, 100, "White", "Wood"));
+        ProductSku sku = productSkuRepository.save(ProductSkuFixture.sku(product, 45000L, 100));
 
         String reqBody = """
             {
                 "categoryId": %d,
                 "name": "New Name",
                 "description": "새로운 설명",
-                "weight": 20.0,
-                "width": 200.0,
-                "height": 120.0,
-                "depth": 60.0,
+                "weight": 40.5,
+                "width": 150.0,
+                "height": 100.0,
+                "depth": 50.0,
                 "skus": [{
                     "id": %d,
                     "price": 75000,
@@ -594,6 +587,11 @@ class AdminProductControllerV1Test extends IntegrationTestBase {
         Product updated = productRepository.findById(product.getId()).orElseThrow();
         assertThat(updated.getName()).isEqualTo("New Name");
         assertThat(updated.getBasePrice()).isEqualTo(75000);
+
+        ProductSku updatedSku = productSkuRepository.findById(sku.getId()).orElseThrow();
+        assertThat(updatedSku.getStockQuantity()).isEqualTo(80);
+        assertThat(updatedSku.getColor()).isEqualTo("Black");
+        assertThat(updatedSku.getMaterial()).isEqualTo("Metal");
     }
 
     @Test
@@ -601,19 +599,18 @@ class AdminProductControllerV1Test extends IntegrationTestBase {
     void updateCompleteSuccess_withCompositions() throws Exception {
         // given
         Category category = categoryRepository.save(CategoryFixture.rootActive());
-        Dimension dimension = Dimension.of(40.5, 150.0, 100.0, 50.0);
 
         Product componentProduct = productRepository.save(
-            Product.create(category, "Chair Leg", null, ProductType.COMPONENT, dimension)
+            ProductFixture.component(category, "Chair Leg")
         );
-        ProductSku oldChildSku = productSkuRepository.save(ProductSku.create(componentProduct, 5000L, 100, "White", "Wood"));
-        ProductSku newChildSku = productSkuRepository.save(ProductSku.create(componentProduct, 5000L, 100, "Black", "Metal"));
+        ProductSku oldChildSku = productSkuRepository.save(ProductSkuFixture.sku(componentProduct, 5000L, 100));
+        ProductSku newChildSku = productSkuRepository.save(ProductSkuFixture.sku(componentProduct, 5000L, 100, "Black", "Metal"));
 
         Product completeProduct = productRepository.save(
-            Product.create(category, "A Desk", null, ProductType.COMPLETE, dimension)
+            ProductFixture.complete(category, "A Desk")
         );
-        ProductSku completeSku = productSkuRepository.save(ProductSku.create(completeProduct, 90000L, 50, "White", "Wood"));
-        compositionRepository.save(com.fittura.domain.product.sku.entity.ProductComposition.create(completeProduct, oldChildSku, 4, 0));
+        ProductSku completeSku = productSkuRepository.save(ProductSkuFixture.sku(completeProduct, 90000L, 50));
+        compositionRepository.save(ProductCompositionFixture.composition(completeProduct, oldChildSku, 4, 0));
 
         long compositionCountBefore = compositionRepository.count();
 
@@ -621,14 +618,14 @@ class AdminProductControllerV1Test extends IntegrationTestBase {
             {
                 "categoryId": %d,
                 "name": "A Desk Updated",
-                "weight": 20.0,
-                "width": 200.0,
-                "height": 120.0,
-                "depth": 60.0,
+                "weight": 40.5,
+                "width": 150.0,
+                "height": 100.0,
+                "depth": 50.0,
                 "skus": [{
                     "id": %d,
-                    "price": 110000,
-                    "stockQuantity": 40,
+                    "price": 90000,
+                    "stockQuantity": 50,
                     "color": "White",
                     "material": "Wood"
                 }],
@@ -663,11 +660,10 @@ class AdminProductControllerV1Test extends IntegrationTestBase {
     void updateSuccess_withNewAttribute() throws Exception {
         // given
         Category category = categoryRepository.save(CategoryFixture.rootActive());
-        Dimension dimension = Dimension.of(40.5, 150.0, 100.0, 50.0);
         Product product = productRepository.save(
-            Product.create(category, "A Desk", null, ProductType.COMPONENT, dimension)
+            ProductFixture.component(category, "A Desk")
         );
-        ProductSku sku = productSkuRepository.save(ProductSku.create(product, 45000L, 100, "White", "Wood"));
+        ProductSku sku = productSkuRepository.save(ProductSkuFixture.sku(product, 45000L, 100));
 
         String reqBody = """
             {
@@ -714,10 +710,10 @@ class AdminProductControllerV1Test extends IntegrationTestBase {
             {
                 "categoryId": %d,
                 "name": "New Name",
-                "weight": 20.0,
-                "width": 200.0,
-                "height": 120.0,
-                "depth": 60.0,
+                "weight": 40.5,
+                "width": 150.0,
+                "height": 100.0,
+                "depth": 50.0,
                 "skus": [{
                     "id": null,
                     "price": 75000,
@@ -748,10 +744,10 @@ class AdminProductControllerV1Test extends IntegrationTestBase {
             {
                 "categoryId": 1,
                 "name": "New Name",
-                "weight": 20.0,
-                "width": 200.0,
-                "height": 120.0,
-                "depth": 60.0,
+                "weight": 40.5,
+                "width": 150.0,
+                "height": 100.0,
+                "depth": 50.0,
                 "skus": [],
                 "attributes": [],
                 "compositions": []
@@ -777,10 +773,10 @@ class AdminProductControllerV1Test extends IntegrationTestBase {
             {
                 "categoryId": 1,
                 "name": "New Name",
-                "weight": 20.0,
-                "width": 200.0,
-                "height": 120.0,
-                "depth": 60.0,
+                "weight": 40.5,
+                "width": 150.0,
+                "height": 100.0,
+                "depth": 50.0,
                 "skus": [{"price": 75000, "stockQuantity": 80}],
                 "attributes": [],
                 "compositions": []
@@ -801,24 +797,23 @@ class AdminProductControllerV1Test extends IntegrationTestBase {
     void updateFail_categoryNotFound() throws Exception {
         // given
         Category category = categoryRepository.save(CategoryFixture.rootActive());
-        Dimension dimension = Dimension.of(40.5, 150.0, 100.0, 50.0);
         Product product = productRepository.save(
-            Product.create(category, "A Desk", null, ProductType.COMPONENT, dimension)
+            ProductFixture.component(category, "A Desk")
         );
-        ProductSku sku = productSkuRepository.save(ProductSku.create(product, 45000L, 100, "White", "Wood"));
+        ProductSku sku = productSkuRepository.save(ProductSkuFixture.sku(product, 45000L, 100));
 
         String reqBody = """
             {
                 "categoryId": 9999,
                 "name": "New Name",
-                "weight": 20.0,
-                "width": 200.0,
-                "height": 120.0,
-                "depth": 60.0,
+                "weight": 40.5,
+                "width": 150.0,
+                "height": 100.0,
+                "depth": 50.0,
                 "skus": [{
                     "id": %d,
-                    "price": 75000,
-                    "stockQuantity": 80,
+                    "price": 45000,
+                    "stockQuantity": 100,
                     "color": "White",
                     "material": "Wood"
                 }],
@@ -892,8 +887,8 @@ class AdminProductControllerV1Test extends IntegrationTestBase {
         // given
         Category category = categoryRepository.save(CategoryFixture.rootActive());
         Product product = productRepository.save(ProductFixture.component(category, "Chair Leg"));
-        ProductSku sku = productSkuRepository.save(ProductSku.create(product, 5000L, 100, "White", "Wood"));
-        productAttributeRepository.save(ProductAttribute.create(product, AttributeKey.SIZE_LABEL, "L"));
+        ProductSku sku = productSkuRepository.save(ProductSkuFixture.sku(product, 5000L, 100));
+        productAttributeRepository.save(ProductAttributeFixture.productAttribute(product, AttributeKey.SIZE_LABEL, "L"));
 
         // when & then
         mockMvc.perform(delete(PRODUCT_ADMIN_URL + "/" + product.getId()))
@@ -918,11 +913,11 @@ class AdminProductControllerV1Test extends IntegrationTestBase {
         Category category = categoryRepository.save(CategoryFixture.rootActive());
 
         Product componentProduct = productRepository.save(ProductFixture.component(category, "Chair Leg"));
-        ProductSku componentSku = productSkuRepository.save(ProductSku.create(componentProduct, 5000L, 100, "White", "Wood"));
+        ProductSku componentSku = productSkuRepository.save(ProductSkuFixture.sku(componentProduct, 5000L, 100));
 
         Product completeProduct = productRepository.save(ProductFixture.complete(category, "A Desk"));
-        ProductSku completeSku = productSkuRepository.save(ProductSku.create(completeProduct, 90000L, 50, "White", "Wood"));
-        compositionRepository.save(ProductComposition.create(completeProduct, componentSku, 4, 0));
+        ProductSku completeSku = productSkuRepository.save(ProductSkuFixture.sku(completeProduct, 90000L, 50));
+        compositionRepository.save(ProductCompositionFixture.composition(completeProduct, componentSku, 4, 0));
 
         // when & then
         mockMvc.perform(delete(PRODUCT_ADMIN_URL + "/" + completeProduct.getId()))
@@ -973,11 +968,11 @@ class AdminProductControllerV1Test extends IntegrationTestBase {
         Category category = categoryRepository.save(CategoryFixture.rootActive());
 
         Product componentProduct = productRepository.save(ProductFixture.component(category, "Chair Leg"));
-        ProductSku componentSku = productSkuRepository.save(ProductSku.create(componentProduct, 5000L, 100, "White", "Wood"));
+        ProductSku componentSku = productSkuRepository.save(ProductSkuFixture.sku(componentProduct, 5000L, 100));
 
         Product completeProduct = productRepository.save(ProductFixture.complete(category, "A Desk"));
-        productSkuRepository.save(ProductSku.create(completeProduct, 90000L, 50, "White", "Wood"));
-        compositionRepository.save(ProductComposition.create(completeProduct, componentSku, 4, 0));
+        productSkuRepository.save(ProductSkuFixture.sku(completeProduct, 90000L, 50));
+        compositionRepository.save(ProductCompositionFixture.composition(completeProduct, componentSku, 4, 0));
 
         // when & then
         mockMvc.perform(delete(PRODUCT_ADMIN_URL + "/" + componentProduct.getId()))

--- a/src/test/java/com/fittura/domain/product/product/controller/ProductControllerV1Test.java
+++ b/src/test/java/com/fittura/domain/product/product/controller/ProductControllerV1Test.java
@@ -4,18 +4,17 @@ import com.fittura.domain.category.entity.Category;
 import com.fittura.domain.category.repository.CategoryRepository;
 import com.fittura.domain.category.support.CategoryFixture;
 import com.fittura.domain.product.product.constant.AttributeKey;
-import com.fittura.domain.product.product.constant.ProductType;
-import com.fittura.domain.product.product.entity.Dimension;
 import com.fittura.domain.product.product.entity.Product;
-import com.fittura.domain.product.product.entity.ProductAttribute;
 import com.fittura.domain.product.product.error.ProductErrorCode;
 import com.fittura.domain.product.product.repository.ProductAttributeRepository;
 import com.fittura.domain.product.product.repository.ProductRepository;
+import com.fittura.domain.product.product.support.ProductAttributeFixture;
 import com.fittura.domain.product.product.support.ProductFixture;
-import com.fittura.domain.product.sku.entity.ProductComposition;
 import com.fittura.domain.product.sku.entity.ProductSku;
 import com.fittura.domain.product.sku.repository.CompositionRepository;
 import com.fittura.domain.product.sku.repository.ProductSkuRepository;
+import com.fittura.domain.product.sku.support.ProductCompositionFixture;
+import com.fittura.domain.product.sku.support.ProductSkuFixture;
 import com.fittura.global.IntegrationTestBase;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -57,13 +56,12 @@ class ProductControllerV1Test extends IntegrationTestBase {
     void getProductsSuccess() throws Exception {
         // given
         Category category = categoryRepository.save(CategoryFixture.rootActive());
-        Dimension dimension = Dimension.of(40.5, 150.0, 100.0, 50.0);
 
-        Product activeProduct = Product.create(category, "Active Desk", null, ProductType.COMPONENT, dimension);
+        Product activeProduct = ProductFixture.component(category, "Active Desk");
         activeProduct.activate();
         productRepository.save(activeProduct);
 
-        Product discontinuedProduct = Product.create(category, "Discontinued Chair", null, ProductType.COMPONENT, dimension);
+        Product discontinuedProduct = ProductFixture.component(category, "Discontinued Chair");
         discontinuedProduct.discontinue();
         productRepository.save(discontinuedProduct);
 
@@ -80,13 +78,12 @@ class ProductControllerV1Test extends IntegrationTestBase {
     void getProducts_excludesDiscontinued() throws Exception {
         // given
         Category category = categoryRepository.save(CategoryFixture.rootActive());
-        Dimension dimension = Dimension.of(40.5, 150.0, 100.0, 50.0);
 
-        Product activeProduct = Product.create(category, "Active Desk", null, ProductType.COMPONENT, dimension);
+        Product activeProduct = ProductFixture.component(category, "Active Desk");
         activeProduct.activate();
         productRepository.save(activeProduct);
 
-        Product discontinuedProduct = Product.create(category, "Discontinued Chair", null, ProductType.COMPONENT, dimension);
+        Product discontinuedProduct = ProductFixture.component(category, "Discontinued Chair");
         discontinuedProduct.discontinue();
         productRepository.save(discontinuedProduct);
 
@@ -103,13 +100,12 @@ class ProductControllerV1Test extends IntegrationTestBase {
     void getProducts_keyword() throws Exception {
         // given
         Category category = categoryRepository.save(CategoryFixture.rootActive());
-        Dimension dimension = Dimension.of(40.5, 150.0, 100.0, 50.0);
 
-        Product desk = Product.create(category, "A Desk", null, ProductType.COMPONENT, dimension);
+        Product desk = ProductFixture.component(category, "A Desk");
         desk.activate();
         productRepository.save(desk);
 
-        Product chair = Product.create(category, "A Chair", null, ProductType.COMPONENT, dimension);
+        Product chair = ProductFixture.component(category, "A Chair");
         chair.activate();
         productRepository.save(chair);
 
@@ -127,13 +123,12 @@ class ProductControllerV1Test extends IntegrationTestBase {
         // given
         Category category1 = categoryRepository.save(CategoryFixture.rootActive());
         Category category2 = categoryRepository.save(CategoryFixture.rootActive());
-        Dimension dimension = Dimension.of(40.5, 150.0, 100.0, 50.0);
 
-        Product product1 = Product.create(category1, "A Desk", null, ProductType.COMPONENT, dimension);
+        Product product1 = ProductFixture.component(category1, "A Desk");
         product1.activate();
         productRepository.save(product1);
 
-        Product product2 = Product.create(category2, "A Chair", null, ProductType.COMPONENT, dimension);
+        Product product2 = ProductFixture.component(category2, "A Chair");
         product2.activate();
         productRepository.save(product2);
 
@@ -150,22 +145,21 @@ class ProductControllerV1Test extends IntegrationTestBase {
     void getProducts_colorsAndMaterials() throws Exception {
         // given
         Category category = categoryRepository.save(CategoryFixture.rootActive());
-        Dimension dimension = Dimension.of(40.5, 150.0, 100.0, 50.0);
 
-        Product woodProduct = Product.create(category, "Wood White Desk", null, ProductType.COMPONENT, dimension);
+        Product woodProduct = ProductFixture.component(category, "Wood White Desk");
         woodProduct.activate();
         productRepository.save(woodProduct);
-        productSkuRepository.save(ProductSku.create(woodProduct, 50000L, 100, "White", "Wood"));
+        productSkuRepository.save(ProductSkuFixture.sku(woodProduct, 50000L, 100, "White", "Wood"));
 
-        Product woodBrownProduct = Product.create(category, "Wood Brown Desk", null, ProductType.COMPONENT, dimension);
+        Product woodBrownProduct = ProductFixture.component(category, "Wood Brown Desk");
         woodBrownProduct.activate();
         productRepository.save(woodBrownProduct);
-        productSkuRepository.save(ProductSku.create(woodBrownProduct, 60000L, 100, "Brown", "Wood"));
+        productSkuRepository.save(ProductSkuFixture.sku(woodBrownProduct, 60000L, 100, "Brown", "Wood"));
 
-        Product metalProduct = Product.create(category, "Metal Black Chair", null, ProductType.COMPONENT, dimension);
+        Product metalProduct = ProductFixture.component(category, "Metal Black Chair");
         metalProduct.activate();
         productRepository.save(metalProduct);
-        productSkuRepository.save(ProductSku.create(metalProduct, 70000L, 100, "Black", "Metal"));
+        productSkuRepository.save(ProductSkuFixture.sku(metalProduct, 70000L, 100, "Black", "Metal"));
 
         // when & then
         mockMvc.perform(get(PRODUCT_URL)
@@ -183,10 +177,9 @@ class ProductControllerV1Test extends IntegrationTestBase {
     void getProducts_excludesDisabled() throws Exception {
         // given
         Category category = categoryRepository.save(CategoryFixture.rootActive());
-        Dimension dimension = Dimension.of(40.5, 150.0, 100.0, 50.0);
 
         // DISABLED는 Product.create()의 기본 상태
-        productRepository.save(Product.create(category, "Hidden Desk", null, ProductType.COMPONENT, dimension));
+        productRepository.save(ProductFixture.component(category, "Hidden Desk"));
 
         // when & then
         mockMvc.perform(get(PRODUCT_URL))
@@ -200,13 +193,12 @@ class ProductControllerV1Test extends IntegrationTestBase {
     void getProducts_defaultSortByLatest() throws Exception {
         // given
         Category category = categoryRepository.save(CategoryFixture.rootActive());
-        Dimension dimension = Dimension.of(40.5, 150.0, 100.0, 50.0);
 
-        Product first = Product.create(category, "First Desk", null, ProductType.COMPONENT, dimension);
+        Product first = ProductFixture.component(category, "First Desk");
         first.activate();
         productRepository.save(first);
 
-        Product second = Product.create(category, "Second Chair", null, ProductType.COMPONENT, dimension);
+        Product second = ProductFixture.component(category, "Second Chair");
         second.activate();
         productRepository.save(second);
 
@@ -223,18 +215,17 @@ class ProductControllerV1Test extends IntegrationTestBase {
     void getProducts_sortByPriceAsc() throws Exception {
         // given
         Category category = categoryRepository.save(CategoryFixture.rootActive());
-        Dimension dimension = Dimension.of(40.5, 150.0, 100.0, 50.0);
 
-        Product expensive = Product.create(category, "Expensive Desk", null, ProductType.COMPONENT, dimension);
+        Product expensive = ProductFixture.component(category, "Expensive Desk");
         expensive.activate();
-        ProductSku.create(expensive, 100000L, 100, "White", "Wood");
+        ProductSkuFixture.sku(expensive, 100000L, 100);
         expensive.syncBasePrice();
         productRepository.save(expensive);
         productSkuRepository.save(expensive.getProductSkus().get(0));
 
-        Product cheap = Product.create(category, "Cheap Chair", null, ProductType.COMPONENT, dimension);
+        Product cheap = ProductFixture.component(category, "Cheap Chair");
         cheap.activate();
-        ProductSku.create(cheap, 45000L, 100, "White", "Wood");
+        ProductSkuFixture.sku(cheap, 45000L, 100);
         cheap.syncBasePrice();
         productRepository.save(cheap);
         productSkuRepository.save(cheap.getProductSkus().get(0));
@@ -254,7 +245,7 @@ class ProductControllerV1Test extends IntegrationTestBase {
         Category category = categoryRepository.save(CategoryFixture.rootActive());
         Product product = productRepository.save(ProductFixture.component(category, "Chair"));
         product.activate();
-        ProductSku sku = productSkuRepository.save(ProductSku.create(product, 5000L, 0, "White", "Wood"));
+        ProductSku sku = productSkuRepository.save(ProductSkuFixture.sku(product, 5000L, 0));
         sku.soldOut();
         productSkuRepository.save(sku);
 
@@ -272,11 +263,10 @@ class ProductControllerV1Test extends IntegrationTestBase {
     void getProductSuccess() throws Exception {
         // given
         Category category = categoryRepository.save(CategoryFixture.rootActive());
-        Dimension dimension = Dimension.of(40.5, 150.0, 100.0, 50.0);
-        Product product = Product.create(category, "A Desk", "책상입니다.", ProductType.COMPONENT, dimension);
+        Product product = ProductFixture.component(category, "A Desk");
         product.activate();
         productRepository.save(product);
-        productSkuRepository.save(ProductSku.create(product, 45000L, 100, "White", "Wood"));
+        productSkuRepository.save(ProductSkuFixture.sku(product, 45000L, 100));
 
         // when & then
         mockMvc.perform(get(PRODUCT_URL + "/" + product.getId()))
@@ -296,7 +286,7 @@ class ProductControllerV1Test extends IntegrationTestBase {
         product.activate();
         productRepository.save(product);
 
-        ProductSku sku = productSkuRepository.save(ProductSku.create(product, 5000L, 0, "White", "Wood"));
+        ProductSku sku = productSkuRepository.save(ProductSkuFixture.sku(product, 5000L, 0));
         sku.soldOut();
         productSkuRepository.save(sku);
 
@@ -321,9 +311,8 @@ class ProductControllerV1Test extends IntegrationTestBase {
     void getProductFail_disabled() throws Exception {
         // given
         Category category = categoryRepository.save(CategoryFixture.rootActive());
-        Dimension dimension = Dimension.of(40.5, 150.0, 100.0, 50.0);
         Product product = productRepository.save(
-            Product.create(category, "A Desk", "책상입니다.", ProductType.COMPONENT, dimension)
+            ProductFixture.component(category, "A Desk")
         );
 
         // when & then
@@ -340,11 +329,10 @@ class ProductControllerV1Test extends IntegrationTestBase {
     void getProductAttributesSuccess() throws Exception {
         // given
         Category category = categoryRepository.save(CategoryFixture.rootActive());
-        Dimension dimension = Dimension.of(40.5, 150.0, 100.0, 50.0);
-        Product product = Product.create(category, "A Desk", "책상입니다.", ProductType.COMPONENT, dimension);
+        Product product = ProductFixture.component(category, "A Desk");
         product.activate();
         productRepository.save(product);
-        ProductAttribute.create(product, AttributeKey.SIZE_LABEL, "XL");
+        ProductAttributeFixture.productAttribute(product, AttributeKey.SIZE_LABEL, "XL");
         attributeRepository.save(product.getAttributes().get(0));
 
         // when & then
@@ -361,8 +349,7 @@ class ProductControllerV1Test extends IntegrationTestBase {
     void getProductAttributesSuccess_empty() throws Exception {
         // given
         Category category = categoryRepository.save(CategoryFixture.rootActive());
-        Dimension dimension = Dimension.of(40.5, 150.0, 100.0, 50.0);
-        Product product = Product.create(category, "A Desk", "책상입니다.", ProductType.COMPONENT, dimension);
+        Product product = ProductFixture.component(category, "A Desk");
         product.activate();
         productRepository.save(product);
 
@@ -391,20 +378,19 @@ class ProductControllerV1Test extends IntegrationTestBase {
     void getProductCompositionsSuccess() throws Exception {
         // given
         Category category = categoryRepository.save(CategoryFixture.rootActive());
-        Dimension dimension = Dimension.of(40.5, 150.0, 100.0, 50.0);
 
-        Product childProduct = Product.create(category, "의자 다리", null, ProductType.COMPONENT, dimension);
+        Product childProduct = ProductFixture.component(category, "의자 다리");
         childProduct.activate();
         productRepository.save(childProduct);
 
-        ProductSku childSku = ProductSku.create(childProduct, 10000L, 100, null, null);
+        ProductSku childSku = ProductSkuFixture.skuWithNoOption(childProduct);
         productSkuRepository.save(childSku);
 
-        Product parentProduct = Product.create(category, "완제품 의자", null, ProductType.COMPLETE, dimension);
+        Product parentProduct = ProductFixture.complete(category, "완제품 의자");
         parentProduct.activate();
         productRepository.save(parentProduct);
 
-        compositionRepository.save(ProductComposition.create(parentProduct, childSku, 4, 0));
+        compositionRepository.save(ProductCompositionFixture.composition(parentProduct, childSku, 4, 0));
 
         // when & then
         mockMvc.perform(get(PRODUCT_URL + "/" + parentProduct.getId() + "/compositions"))
@@ -420,8 +406,7 @@ class ProductControllerV1Test extends IntegrationTestBase {
     void getProductCompositionsSuccess_empty() throws Exception {
         // given
         Category category = categoryRepository.save(CategoryFixture.rootActive());
-        Dimension dimension = Dimension.of(40.5, 150.0, 100.0, 50.0);
-        Product product = Product.create(category, "완제품 의자", null, ProductType.COMPLETE, dimension);
+        Product product = ProductFixture.complete(category, "완제품 의자");
         product.activate();
         productRepository.save(product);
 

--- a/src/test/java/com/fittura/domain/product/product/service/ProductServiceTest.java
+++ b/src/test/java/com/fittura/domain/product/product/service/ProductServiceTest.java
@@ -15,6 +15,7 @@ import com.fittura.domain.product.product.entity.ProductAttribute;
 import com.fittura.domain.product.product.error.ProductErrorCode;
 import com.fittura.domain.product.product.repository.ProductAttributeRepository;
 import com.fittura.domain.product.product.repository.ProductRepository;
+import com.fittura.domain.product.product.support.ProductAttributeFixture;
 import com.fittura.domain.product.product.support.ProductFixture;
 import com.fittura.domain.product.sku.constant.SkuStatus;
 import com.fittura.domain.product.sku.dto.request.CompositionCreateReqDto;
@@ -509,7 +510,7 @@ class ProductServiceTest {
     void updateProductAttributeSuccess_updateExisting() {
         // given
         Product product = ProductFixture.component("A Desk");
-        ProductAttribute existing = ProductAttribute.create(product, AttributeKey.SIZE_LABEL, "M");
+        ProductAttribute existing = ProductAttributeFixture.productAttribute(product, AttributeKey.SIZE_LABEL, "M");
         ReflectionTestUtils.setField(existing, "id", 1L);
 
         given(attributeRepository.findByProductId(product.getId())).willReturn(List.of(existing));
@@ -550,7 +551,7 @@ class ProductServiceTest {
     void updateProductAttributeSuccess_deleteRemoved() {
         // given
         Product product = ProductFixture.component("A Desk");
-        ProductAttribute toDelete = ProductAttribute.create(product, AttributeKey.SIZE_LABEL, "M");
+        ProductAttribute toDelete = ProductAttributeFixture.productAttribute(product, AttributeKey.SIZE_LABEL, "M");
 
         given(attributeRepository.findByProductId(product.getId())).willReturn(List.of(toDelete));
 

--- a/src/test/java/com/fittura/domain/product/sku/support/ProductSkuFixture.java
+++ b/src/test/java/com/fittura/domain/product/sku/support/ProductSkuFixture.java
@@ -18,6 +18,16 @@ public class ProductSkuFixture {
         );
     }
 
+    public static ProductSku sku(Product product, Long price, Integer stock, String color, String material) {
+        return ProductSku.create(
+            product,
+            price,
+            stock,
+            color,
+            material
+        );
+    }
+
     public static ProductSku skuWithOption(Product product, String color, String material) {
         return ProductSku.create(
             product,


### PR DESCRIPTION
## 기능 설명
검증 실패 이전에 저장된 Order가 롤백되지 않고 남는 문제 선검증으로 해결

## 주요 사항
- 주문 관련 엔티티 생성 전 선검증
  -> 주문 저장 전 재고·상태 선검증으로 실패 시 불필요한 저장 방지
- ItemError 도입
- 테스트 코드에 Fixture 적용 누락 수정 

## 관련 이슈
Closes #95 