### PR TITLE
[feat] 주문 생성 시 재고 동시성 처리

### DIFF
--- a/src/main/java/com/fittura/domain/member/entity/Member.java
+++ b/src/main/java/com/fittura/domain/member/entity/Member.java
@@ -12,9 +12,10 @@ import java.util.Set;
 
 import static lombok.AccessLevel.PROTECTED;
 
-@Entity
-@NoArgsConstructor(access = PROTECTED)
 @Getter
+@Entity
+@Table(name = "members")
+@NoArgsConstructor(access = PROTECTED)
 public class Member extends BaseEntity {
 
     @Column(unique = true, nullable = false, length = 254)

--- a/src/main/java/com/fittura/domain/order/cart/repository/CartItemRepository.java
+++ b/src/main/java/com/fittura/domain/order/cart/repository/CartItemRepository.java
@@ -6,13 +6,10 @@ import com.fittura.domain.product.sku.entity.ProductSku;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface CartItemRepository extends JpaRepository<CartItem,Long>, CartItemRepositoryCustom {
-
-    List<CartItem> findAllByIdInAndCart_MemberId(List<Long> itemIds, Long memberId);
 
     Optional<CartItem> findByCartAndProductSku(Cart cart, ProductSku sku);
 

--- a/src/main/java/com/fittura/domain/order/cart/repository/CartItemRepositoryCustom.java
+++ b/src/main/java/com/fittura/domain/order/cart/repository/CartItemRepositoryCustom.java
@@ -1,9 +1,11 @@
 package com.fittura.domain.order.cart.repository;
 
 import com.fittura.domain.order.cart.dto.response.CartItemResDto;
+import com.fittura.domain.order.cart.entity.CartItem;
 
 import java.util.List;
 
 public interface CartItemRepositoryCustom {
+    List<CartItem> findAllWithSkuForUpdate(List<Long> itemIds, Long memberId);
     List<CartItemResDto> findCartItemDtosByCart(Long cartId);
 }

--- a/src/main/java/com/fittura/domain/order/cart/repository/CartItemRepositoryImpl.java
+++ b/src/main/java/com/fittura/domain/order/cart/repository/CartItemRepositoryImpl.java
@@ -7,6 +7,7 @@ import com.fittura.domain.product.sku.constant.SkuStatus;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.CaseBuilder;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.LockModeType;
 import lombok.RequiredArgsConstructor;
 
 import java.util.List;
@@ -32,7 +33,8 @@ public class CartItemRepositoryImpl implements CartItemRepositoryCustom {
                 productSku.status.ne(SkuStatus.ARCHIVED),
                 product.status.ne(ProductStatus.ARCHIVED)
             )
-            .orderBy(cartItem.id.asc())
+            .orderBy(productSku.id.asc())
+            .setLockMode(LockModeType.PESSIMISTIC_WRITE)
             .fetch();
     }
 

--- a/src/main/java/com/fittura/domain/order/cart/repository/CartItemRepositoryImpl.java
+++ b/src/main/java/com/fittura/domain/order/cart/repository/CartItemRepositoryImpl.java
@@ -1,6 +1,7 @@
 package com.fittura.domain.order.cart.repository;
 
 import com.fittura.domain.order.cart.dto.response.CartItemResDto;
+import com.fittura.domain.order.cart.entity.CartItem;
 import com.fittura.domain.product.product.constant.ProductStatus;
 import com.fittura.domain.product.sku.constant.SkuStatus;
 import com.querydsl.core.types.Projections;
@@ -18,6 +19,22 @@ import static com.fittura.domain.product.sku.entity.QProductSku.productSku;
 public class CartItemRepositoryImpl implements CartItemRepositoryCustom {
 
     private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<CartItem> findAllWithSkuForUpdate(List<Long> itemIds, Long memberId) {
+        return queryFactory
+            .selectFrom(cartItem)
+            .join(cartItem.productSku, productSku).fetchJoin()
+            .join(productSku.product, product).fetchJoin()
+            .where(
+                cartItem.id.in(itemIds),
+                cartItem.cart.memberId.eq(memberId),
+                productSku.status.ne(SkuStatus.ARCHIVED),
+                product.status.ne(ProductStatus.ARCHIVED)
+            )
+            .orderBy(cartItem.id.asc())
+            .fetch();
+    }
 
     @Override
     public List<CartItemResDto> findCartItemDtosByCart(Long cartId) {

--- a/src/main/java/com/fittura/domain/order/cart/repository/CartItemRepositoryImpl.java
+++ b/src/main/java/com/fittura/domain/order/cart/repository/CartItemRepositoryImpl.java
@@ -23,6 +23,30 @@ public class CartItemRepositoryImpl implements CartItemRepositoryCustom {
 
     @Override
     public List<CartItem> findAllWithSkuForUpdate(List<Long> itemIds, Long memberId) {
+        List<Long> skuIds = queryFactory
+            .select(cartItem.productSku.id)
+            .from(cartItem)
+            .where(
+                cartItem.id.in(itemIds),
+                cartItem.cart.memberId.eq(memberId)
+            )
+            .fetch();
+
+        if (skuIds.isEmpty()) {
+            return List.of();
+        }
+
+        List<Long> sortedSkuIds = skuIds.stream().distinct().sorted().toList();
+
+        // 이 시점에 ProductSku를 처음 로딩 → 락 걸린 채로 최신 데이터가 세션에 캐싱됨
+        queryFactory
+            .selectFrom(productSku)
+            .where(productSku.id.in(sortedSkuIds))
+            .orderBy(productSku.id.asc())
+            .setLockMode(LockModeType.PESSIMISTIC_WRITE)
+            .fetch();
+
+        // productSku는 이미 세션에 락 걸린 최신 상태로 있음 (인스턴스 재사용)
         return queryFactory
             .selectFrom(cartItem)
             .join(cartItem.productSku, productSku).fetchJoin()
@@ -34,7 +58,6 @@ public class CartItemRepositoryImpl implements CartItemRepositoryCustom {
                 product.status.ne(ProductStatus.ARCHIVED)
             )
             .orderBy(productSku.id.asc())
-            .setLockMode(LockModeType.PESSIMISTIC_WRITE)
             .fetch();
     }
 

--- a/src/main/java/com/fittura/domain/order/cart/service/CartService.java
+++ b/src/main/java/com/fittura/domain/order/cart/service/CartService.java
@@ -45,7 +45,7 @@ public class CartService {
 
     public List<CartItem> getItemsByIdAndMember(List<Long> itemIds, Long memberId) {
         List<Long> distinctIds = itemIds.stream().distinct().toList();
-        List<CartItem> cartItems = cartItemRepository.findAllByIdInAndCart_MemberId(distinctIds, memberId);
+        List<CartItem> cartItems = cartItemRepository.findAllWithSkuForUpdate(distinctIds, memberId);
 
         if (cartItems.size() != distinctIds.size()) {
             throw new ServiceException(CartErrorCode.NOT_FOUND_ITEM);

--- a/src/main/java/com/fittura/domain/order/order/error/OrderErrorCode.java
+++ b/src/main/java/com/fittura/domain/order/order/error/OrderErrorCode.java
@@ -15,7 +15,8 @@ public enum OrderErrorCode implements ErrorCode {
     AMOUNT_MUST_BE_POSITIVE(HttpStatus.BAD_REQUEST, "OR400-03", "금액은 0원 이상이어야 합니다."),
     CART_ITEMS_NOT_VALID(HttpStatus.BAD_REQUEST, "OR400-04" , "상품의 상태를 확인해주세요."),
     SKU_MUST_ACTIVE(HttpStatus.BAD_REQUEST, "OR400-05", "판매중인 상품이 아닙니다."),
-    STOCK_NOT_VALID(HttpStatus.BAD_REQUEST, "OR400-06" , "재고가 부족합니다.");
+    PRODUCT_MUST_ACTIVE(HttpStatus.BAD_REQUEST, "OR400-06", "판매중인 상품이 아닙니다."),
+    STOCK_NOT_VALID(HttpStatus.BAD_REQUEST, "OR400-07" , "재고가 부족합니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/fittura/domain/order/order/service/OrderService.java
+++ b/src/main/java/com/fittura/domain/order/order/service/OrderService.java
@@ -75,6 +75,8 @@ public class OrderService {
 
             if (!sku.isActive()) {
                 errors.add(ItemError.of(productName, OrderErrorCode.SKU_MUST_ACTIVE));
+            } else if (!sku.getProduct().isActive()) {
+                errors.add(ItemError.of(productName, OrderErrorCode.PRODUCT_MUST_ACTIVE));
             } else if (!sku.isStockValid(cartItem.getQuantity())) {
                 errors.add(ItemError.of(productName, OrderErrorCode.STOCK_NOT_VALID));
             }

--- a/src/main/java/com/fittura/domain/product/product/entity/Product.java
+++ b/src/main/java/com/fittura/domain/product/product/entity/Product.java
@@ -143,6 +143,10 @@ public class Product extends BaseEntity {
         return productType == ProductType.COMPLETE;
     }
 
+    public boolean isActive() {
+        return status == ProductStatus.ACTIVE;
+    }
+
     public boolean isArchived() {
         return status == ProductStatus.ARCHIVED;
     }

--- a/src/main/java/com/fittura/domain/product/product/repository/ProductRepositoryImpl.java
+++ b/src/main/java/com/fittura/domain/product/product/repository/ProductRepositoryImpl.java
@@ -268,7 +268,7 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
             : productSku.material.in(materials);
     }
 
-    private static BooleanExpression isSoldOut() {
+    private BooleanExpression isSoldOut() {
         QProductSku subSku = new QProductSku("subSku");
 
         return JPAExpressions

--- a/src/test/java/com/fittura/domain/category/controller/AdminCategoryControllerV1Test.java
+++ b/src/test/java/com/fittura/domain/category/controller/AdminCategoryControllerV1Test.java
@@ -23,11 +23,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @WithMockUser(roles = "ADMIN")
 class AdminCategoryControllerV1Test extends IntegrationTestBase {
-    @Autowired
-    private MockMvc mockMvc;
 
-    @Autowired
-    private CategoryRepository categoryRepository;
+    @Autowired private MockMvc mockMvc;
+    @Autowired private CategoryRepository categoryRepository;
 
     private static final String CATEGORY_ADMIN_URL = "/api/admin/v1/categories";
     private static final String CATEGORY_USER_URL = "/api/v1/categories";

--- a/src/test/java/com/fittura/domain/member/controller/AuthControllerV1Test.java
+++ b/src/test/java/com/fittura/domain/member/controller/AuthControllerV1Test.java
@@ -31,20 +31,11 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 class AuthControllerV1Test extends IntegrationTestBase {
 
-    @Autowired
-    private MockMvc mockMvc;
-
-    @Autowired
-    private AppProperties appProperties;
-
-    @Autowired
-    private JwtTokenProvider jwtTokenProvider;
-
-    @Autowired
-    private MemberRepository memberRepository;
-
-    @Autowired
-    private PasswordEncoder passwordEncoder;
+    @Autowired private MockMvc mockMvc;
+    @Autowired private AppProperties appProperties;
+    @Autowired private JwtTokenProvider jwtTokenProvider;
+    @Autowired private MemberRepository memberRepository;
+    @Autowired private PasswordEncoder passwordEncoder;
 
     private static final String SIGN_UP_URL = "/api/v1/auth/signup";
     private static final String SIGN_IN_URL = "/api/v1/auth/signin";

--- a/src/test/java/com/fittura/domain/order/cart/controller/CartControllerV1Test.java
+++ b/src/test/java/com/fittura/domain/order/cart/controller/CartControllerV1Test.java
@@ -35,23 +35,12 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 class CartControllerV1Test extends IntegrationTestBase {
 
-    @Autowired
-    private MockMvc mockMvc;
-
-    @Autowired
-    private CartRepository cartRepository;
-
-    @Autowired
-    private CartItemRepository cartItemRepository;
-
-    @Autowired
-    private CategoryRepository categoryRepository;
-
-    @Autowired
-    private ProductRepository productRepository;
-
-    @Autowired
-    private ProductSkuRepository productSkuRepository;
+    @Autowired private MockMvc mockMvc;
+    @Autowired private CartRepository cartRepository;
+    @Autowired private CartItemRepository cartItemRepository;
+    @Autowired private CategoryRepository categoryRepository;
+    @Autowired private ProductRepository productRepository;
+    @Autowired private ProductSkuRepository productSkuRepository;
 
     private static final String CART_URL = "/api/v1/cart";
 

--- a/src/test/java/com/fittura/domain/order/cart/service/CartServiceTest.java
+++ b/src/test/java/com/fittura/domain/order/cart/service/CartServiceTest.java
@@ -109,7 +109,7 @@ class CartServiceTest {
         CartItem item1 = CartItemFixture.cartItemWithId(1L, cart, sku, 2);
         CartItem item2 = CartItemFixture.cartItemWithId(2L, cart, sku, 1);
 
-        given(cartItemRepository.findAllByIdInAndCart_MemberId(itemIds, memberId))
+        given(cartItemRepository.findAllWithSkuForUpdate(itemIds, memberId))
             .willReturn(List.of(item1, item2));
 
         // when
@@ -131,7 +131,7 @@ class CartServiceTest {
         Cart cart = CartFixture.cartWithId(10L, memberId);
         CartItem item1 = CartItemFixture.cartItemWithId(1L, cart, sku, 2);
 
-        given(cartItemRepository.findAllByIdInAndCart_MemberId(itemIds, memberId))
+        given(cartItemRepository.findAllWithSkuForUpdate(itemIds, memberId))
             .willReturn(List.of(item1));
 
         // when & then
@@ -146,7 +146,7 @@ class CartServiceTest {
         Long memberId = 1L;
         List<Long> itemIds = List.of(999L);
 
-        given(cartItemRepository.findAllByIdInAndCart_MemberId(itemIds, memberId))
+        given(cartItemRepository.findAllWithSkuForUpdate(itemIds, memberId))
             .willReturn(List.of());
 
         // when & then

--- a/src/test/java/com/fittura/domain/order/order/controller/OrderConcurrencyTest.java
+++ b/src/test/java/com/fittura/domain/order/order/controller/OrderConcurrencyTest.java
@@ -1,0 +1,163 @@
+package com.fittura.domain.order.order.controller;
+
+import com.fittura.domain.category.entity.Category;
+import com.fittura.domain.category.repository.CategoryRepository;
+import com.fittura.domain.category.support.CategoryFixture;
+import com.fittura.domain.order.cart.entity.Cart;
+import com.fittura.domain.order.cart.entity.CartItem;
+import com.fittura.domain.order.cart.repository.CartItemRepository;
+import com.fittura.domain.order.cart.repository.CartRepository;
+import com.fittura.domain.order.facade.OrderFacade;
+import com.fittura.domain.order.order.dto.request.AddressCreateReqDto;
+import com.fittura.domain.order.order.dto.request.OrderCreateReqDto;
+import com.fittura.domain.order.order.repository.OrderAddressRepository;
+import com.fittura.domain.order.order.repository.OrderItemRepository;
+import com.fittura.domain.order.order.repository.OrderRepository;
+import com.fittura.domain.product.product.entity.Product;
+import com.fittura.domain.product.product.repository.ProductRepository;
+import com.fittura.domain.product.product.support.ProductFixture;
+import com.fittura.domain.product.sku.entity.ProductSku;
+import com.fittura.domain.product.sku.repository.ProductSkuRepository;
+import com.fittura.domain.product.sku.support.ProductSkuFixture;
+import com.fittura.global.IntegrationTestBase;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.LongStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Transactional(propagation = Propagation.NOT_SUPPORTED)
+public class OrderConcurrencyTest extends IntegrationTestBase {
+
+    @Autowired private OrderFacade orderFacade;
+    @Autowired private OrderAddressRepository addressRepository;
+    @Autowired private OrderItemRepository orderItemRepository;
+    @Autowired private OrderRepository orderRepository;
+    @Autowired private CategoryRepository categoryRepository;
+    @Autowired private ProductRepository productRepository;
+    @Autowired private ProductSkuRepository skuRepository;
+    @Autowired private CartRepository cartRepository;
+    @Autowired private CartItemRepository cartItemRepository;
+
+    private Category category;
+
+    @BeforeEach
+    void setUp() {
+        category = CategoryFixture.rootActive();
+        categoryRepository.save(category);
+    }
+
+    @AfterEach
+    void tearDown() {
+        cartItemRepository.deleteAll();
+        addressRepository.deleteAll();
+        orderItemRepository.deleteAll();
+        orderRepository.deleteAll();
+        cartRepository.deleteAll();
+        skuRepository.deleteAll();
+        productRepository.deleteAll();
+        categoryRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("재고보다 많은 동시 주문이 들어와도 초과 판매되지 않음")
+    void concurrentOrdersDoNotExceedStock() throws InterruptedException {
+        int initialStock = 3;
+        int memberCnt = 5;
+
+        Product chair = ProductFixture.complete(category, "의자");
+        chair.activate();
+        productRepository.save(chair);
+        ProductSku chairSku = ProductSkuFixture.sku(chair, 100_000L, initialStock, "RED", null);
+        skuRepository.save(chairSku);
+
+        List<Long> memberIds = LongStream.rangeClosed(1, memberCnt)
+            .map(i -> 90000L + i)
+            .boxed()
+            .toList();
+
+        List<Long> cartItemIds = new ArrayList<>();
+        for (Long memberId : memberIds) {
+            Cart cart = Cart.create(memberId);
+            cartRepository.save(cart);
+
+            CartItem item = CartItem.create(cart, chairSku, 1);
+            cartItemRepository.save(item);
+            cartItemIds.add(item.getId());
+        }
+
+        // ===== 동시 실행 =====
+        ExecutorService executor = Executors.newFixedThreadPool(memberCnt);
+
+        CountDownLatch readyLatch = new CountDownLatch(memberCnt);
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch doneLatch = new CountDownLatch(memberCnt);
+
+        List<Throwable> failures = Collections.synchronizedList(new ArrayList<>());
+        AtomicInteger successCnt = new AtomicInteger();
+
+        for (int i = 0; i < memberCnt; i++) {
+            Long memberId = memberIds.get(i);
+            Long cartItemId = cartItemIds.get(i);
+
+            executor.submit(() -> {
+                try {
+                    readyLatch.countDown();
+                    startLatch.await();
+
+                    OrderCreateReqDto reqDto = new OrderCreateReqDto(
+                        List.of(cartItemId),
+                        0L,
+                        addressDto()
+                    );
+                    orderFacade.createOrder(memberId, reqDto);
+                    successCnt.incrementAndGet();
+                } catch (Exception e) {
+                    failures.add(e);
+                } finally {
+                    doneLatch.countDown();
+                }
+            });
+
+        }
+        readyLatch.await();
+        startLatch.countDown();
+        boolean finished = doneLatch.await(10, TimeUnit.SECONDS);
+        executor.shutdown();
+
+        // ===== 검증 =====
+        assertThat(finished).isTrue();
+
+        ProductSku result = skuRepository.findById(chairSku.getId()).orElseThrow();
+        assertThat(result.getReservedQuantity()).isLessThanOrEqualTo(result.getStockQuantity());
+        assertThat(successCnt.get()).isEqualTo(initialStock);
+        assertThat(failures).hasSize(memberCnt - initialStock);
+    }
+
+    private AddressCreateReqDto addressDto() {
+        return new AddressCreateReqDto(
+            "홍길동", "01012341234", "12345",
+            "서울특별시 중구 서소문로 127", null, "서울특별시", "중구", null
+        );
+    }
+}

--- a/src/test/java/com/fittura/domain/order/order/controller/OrderConcurrencyTest.java
+++ b/src/test/java/com/fittura/domain/order/order/controller/OrderConcurrencyTest.java
@@ -25,7 +25,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.dao.PessimisticLockingFailureException;
 import org.springframework.test.context.ActiveProfiles;
@@ -44,7 +43,6 @@ import java.util.stream.LongStream;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
-@AutoConfigureMockMvc
 @ActiveProfiles("test")
 @Transactional(propagation = Propagation.NOT_SUPPORTED)
 public class OrderConcurrencyTest extends IntegrationTestBase {
@@ -230,7 +228,7 @@ public class OrderConcurrencyTest extends IntegrationTestBase {
     }
 
     @Test
-    @DisplayName("같은 상품의 다른 SKU를 동시 주문하면 Product row 락 경합으로 직렬화됨")
+    @DisplayName("같은 상품의 다른 SKU를 동시 주문해도 Product 락 경합 없이 독립적으로 처리됨")
     void concurrentOrdersOnSameProductDifferentSkuAreSerialized() throws Exception {
         long holdMillis = 2000L;
 
@@ -282,9 +280,7 @@ public class OrderConcurrencyTest extends IntegrationTestBase {
         // 안 끝나는 상황만 막는 안전장치
         Long executionTimeB = threadB.get(3, TimeUnit.SECONDS);
 
-        // 실제 검증: B의 실행 시간이 A의 락 점유 시간(holdMillis)보다 확실히 짧아야 함
-        // 지금(FOR UPDATE + JOIN 구조)은 Product row 경합 때문에 holdMillis 근처까지 걸려 실패하는 게 정상
-        // FOR UPDATE를 SKU 단위로 좁히는 리팩토링 후에는 이 assertion이 통과해야 함
+        // 락이 SKU 단위로 좁혀졌으므로, A가 다른 SKU의 락을 잡고 있어도 B는 대기 없이 완료해야 함
         assertThat(executionTimeB).isLessThan(holdMillis - 500L);
 
         threadA.get(10, TimeUnit.SECONDS);

--- a/src/test/java/com/fittura/domain/order/order/controller/OrderConcurrencyTest.java
+++ b/src/test/java/com/fittura/domain/order/order/controller/OrderConcurrencyTest.java
@@ -271,7 +271,13 @@ public class OrderConcurrencyTest extends IntegrationTestBase {
 
         // B: A가 락을 잡은 직후, 같은 Product의 다른 SKU(blue) 주문 시도 + 실행 시간 측정
         Future<Long> threadB = executor.submit(() -> {
-            lockAcquiredLatch.await();
+            if (!lockAcquiredLatch.await(2, TimeUnit.SECONDS)) {
+                // A가 신호를 못 줬다면, lockAcquiredLatch.countDown() 전에 예외로 끝났을 가능성이 높음
+                if (threadA.isDone()) {
+                    threadA.get();
+                }
+                throw new AssertionError("스레드 A가 락을 획득하지 못했습니다 (A가 아직 실행 중)");
+            }
             long start = System.nanoTime();
             orderFacade.createOrder(memberY, new OrderCreateReqDto(List.of(itemYBlue.getId()), 0L, address));
             return TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start);

--- a/src/test/java/com/fittura/domain/order/order/controller/OrderConcurrencyTest.java
+++ b/src/test/java/com/fittura/domain/order/order/controller/OrderConcurrencyTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.dao.PessimisticLockingFailureException;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -85,11 +86,7 @@ public class OrderConcurrencyTest extends IntegrationTestBase {
         int initialStock = 3;
         int memberCnt = 5;
 
-        Product chair = ProductFixture.complete(category, "의자");
-        chair.activate();
-        productRepository.save(chair);
-        ProductSku chairSku = ProductSkuFixture.sku(chair, 100_000L, initialStock, "RED", null);
-        skuRepository.save(chairSku);
+        ProductSku chairSku = getProductSku("의자", initialStock);
 
         List<Long> memberIds = LongStream.rangeClosed(1, memberCnt)
             .map(i -> 90000L + i)
@@ -154,10 +151,108 @@ public class OrderConcurrencyTest extends IntegrationTestBase {
         assertThat(failures).hasSize(memberCnt - initialStock);
     }
 
+    @Test
+    @DisplayName("서로 다른 순서로 담긴 카트를 동시 주문해도 데드락이 발생하지 않는다")
+    void concurrentOrdersWithReversedCartOrderDoNotDeadlock() throws InterruptedException {
+        int stockEach = 5;
+
+        ProductSku skuA = getProductSku("의자A", stockEach);
+        ProductSku skuB = getProductSku("의자B", stockEach);
+
+        Long memberX = 91001L;
+        Long memberY = 91002L;
+
+        // 회원 X: 카트에 [skuA, skuB] 순서로 담음
+        Cart cartX = Cart.create(memberX);
+        cartRepository.save(cartX);
+        CartItem itemXA = CartItem.create(cartX, skuA, 1);
+        cartItemRepository.save(itemXA);
+        CartItem itemXB = CartItem.create(cartX, skuB, 1);
+        cartItemRepository.save(itemXB);
+        List<Long> cartItemIdsX = List.of(itemXA.getId(), itemXB.getId());
+
+        // 회원 Y: 카트에 [skuB, skuA] 순서로 담음 (역순)
+        Cart cartY = Cart.create(memberY);
+        cartRepository.save(cartY);
+        CartItem itemYB = CartItem.create(cartY, skuB, 1);
+        cartItemRepository.save(itemYB);
+        CartItem itemYA = CartItem.create(cartY, skuA, 1);
+        cartItemRepository.save(itemYA);
+        List<Long> cartItemIdsY = List.of(itemYB.getId(), itemYA.getId());
+
+        List<OrderTask> tasks = List.of(
+            new OrderTask(memberX, cartItemIdsX),
+            new OrderTask(memberY, cartItemIdsY)
+        );
+        AddressCreateReqDto address = addressDto();
+
+        // ===== 동시 실행 =====
+        ExecutorService executor = Executors.newFixedThreadPool(tasks.size());
+        CountDownLatch readyLatch = new CountDownLatch(tasks.size());
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch doneLatch = new CountDownLatch(tasks.size());
+        List<Throwable> failures = Collections.synchronizedList(new ArrayList<>());
+
+        for (OrderTask task : tasks) {
+            executor.submit(() -> {
+                try {
+                    readyLatch.countDown();
+                    startLatch.await();
+                    orderFacade.createOrder(task.memberId(), new OrderCreateReqDto(task.cartItemIds(), 0L, address));
+                } catch (Throwable e) {
+                    failures.add(e);
+                } finally {
+                    doneLatch.countDown();
+                }
+            });
+        }
+
+        readyLatch.await();
+        startLatch.countDown();
+        boolean finished = doneLatch.await(10, TimeUnit.SECONDS);
+        executor.shutdown();
+
+        // ===== 검증 =====
+        assertThat(finished).isTrue();
+
+        if (!failures.isEmpty()) {
+            failures.forEach(e -> System.out.println(
+                "failure type: " + e.getClass().getName()
+                    + (e.getCause() != null ? " / cause: " + e.getCause().getClass().getName() : "")
+            ));
+        }
+
+        boolean hasDeadlock = failures.stream().anyMatch(this::isDeadlockRelated);
+        assertThat(hasDeadlock).isFalse();
+    }
+
+
+    // ========== 헬퍼 메서드 ==========
+
+    private record OrderTask(Long memberId, List<Long> cartItemIds) {}
+
     private AddressCreateReqDto addressDto() {
         return new AddressCreateReqDto(
             "홍길동", "01012341234", "12345",
             "서울특별시 중구 서소문로 127", null, "서울특별시", "중구", null
         );
+    }
+
+    private ProductSku getProductSku(String productName, int stockEach) {
+        Product product = ProductFixture.complete(category, productName);
+        product.activate();
+        productRepository.save(product);
+        ProductSku sku = ProductSkuFixture.sku(product, 100_000L, stockEach);
+        skuRepository.save(sku);
+        return sku;
+    }
+
+    private boolean isDeadlockRelated(Throwable e) {
+        for (Throwable t = e; t != null; t = t.getCause()) {
+            if (t instanceof PessimisticLockingFailureException) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/src/test/java/com/fittura/domain/order/order/controller/OrderConcurrencyTest.java
+++ b/src/test/java/com/fittura/domain/order/order/controller/OrderConcurrencyTest.java
@@ -29,16 +29,15 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.dao.PessimisticLockingFailureException;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.LongStream;
 
@@ -59,6 +58,7 @@ public class OrderConcurrencyTest extends IntegrationTestBase {
     @Autowired private ProductSkuRepository skuRepository;
     @Autowired private CartRepository cartRepository;
     @Autowired private CartItemRepository cartItemRepository;
+    @Autowired private PlatformTransactionManager transactionManager;
 
     private Category category;
 
@@ -152,7 +152,7 @@ public class OrderConcurrencyTest extends IntegrationTestBase {
     }
 
     @Test
-    @DisplayName("서로 다른 순서로 담긴 카트를 동시 주문해도 데드락이 발생하지 않는다")
+    @DisplayName("서로 다른 순서로 담긴 카트를 동시 주문해도 데드락이 발생하지 않음")
     void concurrentOrdersWithReversedCartOrderDoNotDeadlock() throws InterruptedException {
         int stockEach = 5;
 
@@ -198,7 +198,10 @@ public class OrderConcurrencyTest extends IntegrationTestBase {
                 try {
                     readyLatch.countDown();
                     startLatch.await();
-                    orderFacade.createOrder(task.memberId(), new OrderCreateReqDto(task.cartItemIds(), 0L, address));
+                    orderFacade.createOrder(
+                        task.memberId(),
+                        new OrderCreateReqDto(task.cartItemIds(), 0L, address)
+                    );
                 } catch (Throwable e) {
                     failures.add(e);
                 } finally {
@@ -226,6 +229,68 @@ public class OrderConcurrencyTest extends IntegrationTestBase {
         assertThat(hasDeadlock).isFalse();
     }
 
+    @Test
+    @DisplayName("같은 상품의 다른 SKU를 동시 주문하면 Product row 락 경합으로 직렬화됨")
+    void concurrentOrdersOnSameProductDifferentSkuAreSerialized() throws Exception {
+        long holdMillis = 2000L;
+
+        Product chair = createActiveProduct("의자");
+        ProductSku chairRed = createSku(chair, 5, "red");
+        ProductSku chairBlue = createSku(chair, 5, "blue");
+
+        Long memberX = 92001L;
+        Long memberY = 92002L;
+
+        Cart cartX = Cart.create(memberX);
+        cartRepository.save(cartX);
+        CartItem itemXRed = CartItem.create(cartX, chairRed, 1);
+        cartItemRepository.save(itemXRed);
+
+        Cart cartY = Cart.create(memberY);
+        cartRepository.save(cartY);
+        CartItem itemYBlue = CartItem.create(cartY, chairBlue, 1);
+        cartItemRepository.save(itemYBlue);
+
+        AddressCreateReqDto address = addressDto();
+        TransactionTemplate transactionTemplate = new TransactionTemplate(transactionManager);
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        CountDownLatch lockAcquiredLatch = new CountDownLatch(1);
+
+        // 스레드 A: chairRed 락을 잡고 holdMillis 동안 트랜잭션을 붙잡고 있음
+        Future<?> threadA = executor.submit(() -> {
+            transactionTemplate.execute(status -> {
+                cartItemRepository.findAllWithSkuForUpdate(List.of(itemXRed.getId()), memberX);
+                lockAcquiredLatch.countDown();
+                try {
+                    Thread.sleep(holdMillis);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+                return null;
+            }); // execute()가 리턴하는 시점 = 트랜잭션 커밋 완료 = 락 해제
+            return null;
+        });
+
+        // B: A가 락을 잡은 직후, 같은 Product의 다른 SKU(blue) 주문 시도 + 실행 시간 측정
+        Future<Long> threadB = executor.submit(() -> {
+            lockAcquiredLatch.await();
+            long start = System.nanoTime();
+            orderFacade.createOrder(memberY, new OrderCreateReqDto(List.of(itemYBlue.getId()), 0L, address));
+            return TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start);
+        });
+
+        // 안 끝나는 상황만 막는 안전장치
+        Long executionTimeB = threadB.get(3, TimeUnit.SECONDS);
+
+        // 실제 검증: B의 실행 시간이 A의 락 점유 시간(holdMillis)보다 확실히 짧아야 함
+        // 지금(FOR UPDATE + JOIN 구조)은 Product row 경합 때문에 holdMillis 근처까지 걸려 실패하는 게 정상
+        // FOR UPDATE를 SKU 단위로 좁히는 리팩토링 후에는 이 assertion이 통과해야 함
+        assertThat(executionTimeB).isLessThan(holdMillis - 500L);
+
+        threadA.get(10, TimeUnit.SECONDS);
+        executor.shutdown();
+    }
+
 
     // ========== 헬퍼 메서드 ==========
 
@@ -238,13 +303,21 @@ public class OrderConcurrencyTest extends IntegrationTestBase {
         );
     }
 
-    private ProductSku getProductSku(String productName, int stockEach) {
-        Product product = ProductFixture.complete(category, productName);
+    private Product createActiveProduct(String name) {
+        Product product = ProductFixture.complete(category, name);
         product.activate();
         productRepository.save(product);
-        ProductSku sku = ProductSkuFixture.sku(product, 100_000L, stockEach);
+        return product;
+    }
+
+    private ProductSku createSku(Product product, int stock, String color) {
+        ProductSku sku = ProductSkuFixture.sku(product, 100_000L, stock, color, null);
         skuRepository.save(sku);
         return sku;
+    }
+
+    private ProductSku getProductSku(String productName, int stock) {
+        return createSku(createActiveProduct(productName), stock, null);
     }
 
     private boolean isDeadlockRelated(Throwable e) {

--- a/src/test/java/com/fittura/domain/order/order/controller/OrderControllerTest.java
+++ b/src/test/java/com/fittura/domain/order/order/controller/OrderControllerTest.java
@@ -36,32 +36,15 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 class OrderControllerTest extends IntegrationTestBase {
 
-    @Autowired
-    private MockMvc mockMvc;
-
-    @Autowired
-    private OrderRepository orderRepository;
-
-    @Autowired
-    private OrderItemRepository orderItemRepository;
-
-    @Autowired
-    private OrderAddressRepository addressRepository;
-
-    @Autowired
-    private CartRepository cartRepository;
-
-    @Autowired
-    private CartItemRepository cartItemRepository;
-
-    @Autowired
-    private CategoryRepository categoryRepository;
-
-    @Autowired
-    private ProductRepository productRepository;
-
-    @Autowired
-    private ProductSkuRepository productSkuRepository;
+    @Autowired private MockMvc mockMvc;
+    @Autowired private OrderRepository orderRepository;
+    @Autowired private OrderItemRepository orderItemRepository;
+    @Autowired private OrderAddressRepository addressRepository;
+    @Autowired private CartRepository cartRepository;
+    @Autowired private CartItemRepository cartItemRepository;
+    @Autowired private CategoryRepository categoryRepository;
+    @Autowired private ProductRepository productRepository;
+    @Autowired private ProductSkuRepository productSkuRepository;
 
     private static final String ORDER_URL = "/api/v1/orders";
 

--- a/src/test/java/com/fittura/domain/order/order/controller/OrderControllerTest.java
+++ b/src/test/java/com/fittura/domain/order/order/controller/OrderControllerTest.java
@@ -362,6 +362,7 @@ class OrderControllerTest extends IntegrationTestBase {
     private ProductSku savedDefaultSku(Integer stock) {
         Category category = categoryRepository.save(CategoryFixture.rootActive());
         Product product = productRepository.save(ProductFixture.component(category, "A Desk"));
+        product.activate();
         return productSkuRepository.save(ProductSkuFixture.sku(product, 10000L, stock));
     }
 }

--- a/src/test/java/com/fittura/domain/product/product/controller/AdminProductControllerV1Test.java
+++ b/src/test/java/com/fittura/domain/product/product/controller/AdminProductControllerV1Test.java
@@ -40,23 +40,12 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @WithMockUser(roles = "ADMIN")
 class AdminProductControllerV1Test extends IntegrationTestBase {
 
-    @Autowired
-    private MockMvc mockMvc;
-
-    @Autowired
-    private CategoryRepository categoryRepository;
-
-    @Autowired
-    private ProductRepository productRepository;
-
-    @Autowired
-    private ProductSkuRepository productSkuRepository;
-
-    @Autowired
-    private CompositionRepository compositionRepository;
-
-    @Autowired
-    private ProductAttributeRepository productAttributeRepository;
+    @Autowired private MockMvc mockMvc;
+    @Autowired private CategoryRepository categoryRepository;
+    @Autowired private ProductRepository productRepository;
+    @Autowired private ProductSkuRepository productSkuRepository;
+    @Autowired private CompositionRepository compositionRepository;
+    @Autowired private ProductAttributeRepository productAttributeRepository;
 
     private static final String PRODUCT_ADMIN_URL = "/api/admin/v1/products";
 

--- a/src/test/java/com/fittura/domain/product/product/controller/ProductControllerV1Test.java
+++ b/src/test/java/com/fittura/domain/product/product/controller/ProductControllerV1Test.java
@@ -28,23 +28,12 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 class ProductControllerV1Test extends IntegrationTestBase {
 
-    @Autowired
-    private MockMvc mockMvc;
-
-    @Autowired
-    private CategoryRepository categoryRepository;
-
-    @Autowired
-    private ProductRepository productRepository;
-
-    @Autowired
-    private ProductSkuRepository productSkuRepository;
-
-    @Autowired
-    private ProductAttributeRepository attributeRepository;
-
-    @Autowired
-    private CompositionRepository compositionRepository;
+    @Autowired private MockMvc mockMvc;
+    @Autowired private CategoryRepository categoryRepository;
+    @Autowired private ProductRepository productRepository;
+    @Autowired private ProductSkuRepository productSkuRepository;
+    @Autowired private ProductAttributeRepository attributeRepository;
+    @Autowired private CompositionRepository compositionRepository;
 
     private static final String PRODUCT_URL = "/api/v1/products";
 


### PR DESCRIPTION
## 기능 설명
주문 생성 시 동시성 문제를 비관적 락으로 해결

## 주요 사항
- ProductSku 동시 주문 정합성 보장
- 비관적 락 적용
- 카트 아이템 목록 조회 후 sku, product 마다 N+1 발생하는 문제 패치 조인으로 해결
- 시나리오 1) 동시 주문시 재고 초과 판매 여부
- 시나리오 2) 데드락 회피 (락 순서 정렬 검증)
- 시나리오 3) Product Row 락 경합 (락 범위 검증)

## 관련 이슈
Closes #이슈번호