### PR TITLE
[feat] 주문 취소 골격

### DIFF
--- a/.github/workflows/enforce-base-branch.yml
+++ b/.github/workflows/enforce-base-branch.yml
@@ -1,0 +1,15 @@
+name: Enforce PR source branch
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  check-source:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate head branch
+        run: |
+          if [ "${{ github.head_ref }}" != "develop" ]; then
+            echo "::error::main can only receive PRs from develop. Got: ${{ github.head_ref }}"
+            exit 1
+          fi

--- a/src/main/java/com/fittura/domain/delivery/delivery/constant/DeliveryStatus.java
+++ b/src/main/java/com/fittura/domain/delivery/delivery/constant/DeliveryStatus.java
@@ -6,5 +6,6 @@ public enum DeliveryStatus {
     IN_TRANSIT,   // 배송 중
     DELIVERED,    // 배송 완료
     FAILED,       // 배송 실패
+    CANCELLED,    // 배송 취소
     RETURNED      // 반송
 }

--- a/src/main/java/com/fittura/domain/delivery/delivery/entitiy/Delivery.java
+++ b/src/main/java/com/fittura/domain/delivery/delivery/entitiy/Delivery.java
@@ -57,4 +57,8 @@ public class Delivery extends BaseEntity {
             .deliveryFee(deliveryFee)
             .build();
     }
+
+    public void cancel() {
+        this.status = DeliveryStatus.CANCELLED;
+    }
 }

--- a/src/main/java/com/fittura/domain/order/facade/OrderFacade.java
+++ b/src/main/java/com/fittura/domain/order/facade/OrderFacade.java
@@ -10,6 +10,7 @@ import com.fittura.domain.order.order.dto.response.OrderWithDeliveryResDto;
 import com.fittura.domain.order.order.entity.Claim;
 import com.fittura.domain.order.order.entity.Order;
 import com.fittura.domain.order.order.service.OrderService;
+import com.fittura.domain.product.sku.service.SkuService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -24,6 +25,7 @@ public class OrderFacade {
 
     private final OrderService orderService;
     private final CartService cartService;
+    private final SkuService skuService;
 
     @Transactional(readOnly = true)
     public Page<OrderWithDeliveryResDto> getOrders(Long memberId, OrderSearchCondition searchCondition, Pageable pageable) {
@@ -60,12 +62,26 @@ public class OrderFacade {
 
         Claim claim = orderService.createCancelClaim(order, reqDto);
 
-        // SKU 잠금 후 재고 롤백
+        if (order.isPaid()) {
+            completeCancellation(order, claim);
+        } else {
+            orderService.requestCancel(order, claim.getItems());
+        }
 
         // TODO: OrderItem status → CANCEL_REQUESTED
+    }
+
+    public void completeCancellation(Order order, Claim claim) {
+        claim.approve();
+        skuService.restoreStock(claim.getQuantityBySkuId());
+
         // TODO: Payment 환불 (PG 취소 API)
         // TODO: Point 환급/회수
 
         // 상태 전이: OrderItem, Delivery, Order → CANCELLED
+        claim.complete();
+        orderService.cancelItems(claim.getItems());
+        // Delivery
+        orderService.cancelIfAllItemsCancelled(order);
     }
 }

--- a/src/main/java/com/fittura/domain/order/facade/OrderFacade.java
+++ b/src/main/java/com/fittura/domain/order/facade/OrderFacade.java
@@ -4,8 +4,8 @@ import com.fittura.domain.order.cart.entity.CartItem;
 import com.fittura.domain.order.cart.service.CartService;
 import com.fittura.domain.order.order.dto.request.OrderCreateReqDto;
 import com.fittura.domain.order.order.dto.request.OrderSearchCondition;
-import com.fittura.domain.order.order.dto.response.OrderWithDeliveryResDto;
 import com.fittura.domain.order.order.dto.response.OrderWithAllResDto;
+import com.fittura.domain.order.order.dto.response.OrderWithDeliveryResDto;
 import com.fittura.domain.order.order.entity.Order;
 import com.fittura.domain.order.order.service.OrderService;
 import lombok.RequiredArgsConstructor;
@@ -23,13 +23,14 @@ public class OrderFacade {
     private final OrderService orderService;
     private final CartService cartService;
 
+    @Transactional(readOnly = true)
     public Page<OrderWithDeliveryResDto> getOrders(Long memberId, OrderSearchCondition searchCondition, Pageable pageable) {
         return orderService.getOrders(memberId, searchCondition, pageable);
     }
 
     @Transactional(readOnly = true)
     public OrderWithAllResDto getOrderByIdAndMember(Long orderId, Long memberId) {
-        return orderService.getOrderByIdAndMember(orderId, memberId);
+        return orderService.getOrderDetail(orderId, memberId);
     }
 
     @Transactional

--- a/src/main/java/com/fittura/domain/order/facade/OrderFacade.java
+++ b/src/main/java/com/fittura/domain/order/facade/OrderFacade.java
@@ -7,6 +7,7 @@ import com.fittura.domain.order.order.dto.request.OrderCreateReqDto;
 import com.fittura.domain.order.order.dto.request.OrderSearchCondition;
 import com.fittura.domain.order.order.dto.response.OrderWithAllResDto;
 import com.fittura.domain.order.order.dto.response.OrderWithDeliveryResDto;
+import com.fittura.domain.order.order.entity.Claim;
 import com.fittura.domain.order.order.entity.Order;
 import com.fittura.domain.order.order.service.OrderService;
 import lombok.RequiredArgsConstructor;
@@ -57,7 +58,7 @@ public class OrderFacade {
 
         // TODO: Delivery 목록 조회, 상태 검증
 
-        // OrderClaim 생성 (CANCEL, 사유, 대상 아이템)
+        Claim claim = orderService.createCancelClaim(order, reqDto);
 
         // SKU 잠금 후 재고 롤백
 

--- a/src/main/java/com/fittura/domain/order/facade/OrderFacade.java
+++ b/src/main/java/com/fittura/domain/order/facade/OrderFacade.java
@@ -2,6 +2,7 @@ package com.fittura.domain.order.facade;
 
 import com.fittura.domain.order.cart.entity.CartItem;
 import com.fittura.domain.order.cart.service.CartService;
+import com.fittura.domain.order.order.dto.request.ClaimOrderReqDto;
 import com.fittura.domain.order.order.dto.request.OrderCreateReqDto;
 import com.fittura.domain.order.order.dto.request.OrderSearchCondition;
 import com.fittura.domain.order.order.dto.response.OrderWithAllResDto;
@@ -47,5 +48,23 @@ public class OrderFacade {
         orderService.calcAmount(order);
 
         return order.getId();
+    }
+
+    @Transactional
+    public void cancelOrder(Long memberId, Long orderId, ClaimOrderReqDto reqDto) {
+        Order order = orderService.getOrder(orderId, memberId);
+        order.validateCancel();
+
+        // TODO: Delivery 목록 조회, 상태 검증
+
+        // OrderClaim 생성 (CANCEL, 사유, 대상 아이템)
+
+        // SKU 잠금 후 재고 롤백
+
+        // TODO: OrderItem status → CANCEL_REQUESTED
+        // TODO: Payment 환불 (PG 취소 API)
+        // TODO: Point 환급/회수
+
+        // 상태 전이: OrderItem, Delivery, Order → CANCELLED
     }
 }

--- a/src/main/java/com/fittura/domain/order/order/constant/ClaimReason.java
+++ b/src/main/java/com/fittura/domain/order/order/constant/ClaimReason.java
@@ -1,0 +1,4 @@
+package com.fittura.domain.order.order.constant;
+
+public enum ClaimReason {
+}

--- a/src/main/java/com/fittura/domain/order/order/constant/ClaimReason.java
+++ b/src/main/java/com/fittura/domain/order/order/constant/ClaimReason.java
@@ -1,4 +1,24 @@
 package com.fittura.domain.order.order.constant;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
 public enum ClaimReason {
+
+    // ===== 단순 변심 (고객 귀책) =====
+    CHANGE_OF_MIND("단순 변심"),
+    FOUND_CHEAPER("다른 상품 구매"),
+    DELIVERY_DELAYED("배송 지연"),
+
+    // ===== 상품 문제 (판매자 귀책) =====
+    DEFECTIVE("상품 불량/파손"),
+    WRONG_DELIVERY("오배송"),
+    DIFFERENT_FROM_DESCRIPTION("상품 설명과 다름"),
+
+    // ===== 기타 =====
+    ETC("기타");
+
+    private final String description;
 }

--- a/src/main/java/com/fittura/domain/order/order/constant/ClaimStatus.java
+++ b/src/main/java/com/fittura/domain/order/order/constant/ClaimStatus.java
@@ -1,0 +1,8 @@
+package com.fittura.domain.order.order.constant;
+
+public enum ClaimStatus {
+    REQUESTED,    // 접수
+    APPROVED,     // 승인 (PG 취소 호출 전)
+    COMPLETED,    // 완료 (환불까지 끝남)
+    REJECTED      // 거부
+}

--- a/src/main/java/com/fittura/domain/order/order/constant/ClaimType.java
+++ b/src/main/java/com/fittura/domain/order/order/constant/ClaimType.java
@@ -1,0 +1,7 @@
+package com.fittura.domain.order.order.constant;
+
+public enum ClaimType {
+    CANCEL,
+    REFUND,
+    EXCHANGE
+}

--- a/src/main/java/com/fittura/domain/order/order/constant/OrderStatus.java
+++ b/src/main/java/com/fittura/domain/order/order/constant/OrderStatus.java
@@ -5,8 +5,6 @@ public enum OrderStatus {
     PAID,               // 결제 완료
     PREPARING,          // 상품 준비 중
     COMPLETED,          // 주문 완료 (배송 완료 후)
-    CANCEL_REQUESTED,   // 취소 요청
     CANCELLED,          // 취소 완료
-    RETURN_REQUESTED,   // 반품 요청
     RETURNED            // 반품 완료
 }

--- a/src/main/java/com/fittura/domain/order/order/controller/OrderController.java
+++ b/src/main/java/com/fittura/domain/order/order/controller/OrderController.java
@@ -1,6 +1,7 @@
 package com.fittura.domain.order.order.controller;
 
 import com.fittura.domain.order.facade.OrderFacade;
+import com.fittura.domain.order.order.dto.request.ClaimOrderReqDto;
 import com.fittura.domain.order.order.dto.request.OrderCreateReqDto;
 import com.fittura.domain.order.order.dto.request.OrderSearchCondition;
 import com.fittura.domain.order.order.dto.response.OrderWithAllResDto;
@@ -50,13 +51,13 @@ public class OrderController {
         return ResponseEntity.ok(RsData.success("주문 목록이 조회되었습니다.", resDtos));
     }
 
-    @GetMapping("/{id}")
+    @GetMapping("/{orderId}")
     @Operation(summary = "주문 조회", description = "주문 조회 API")
     public ResponseEntity<RsData<OrderWithAllResDto>> getOrder(
         @LogInMemberId Long memberId,
-        @PathVariable Long id
+        @PathVariable Long orderId
     ) {
-        OrderWithAllResDto resDto = orderFacade.getOrderByIdAndMember(id, memberId);
+        OrderWithAllResDto resDto = orderFacade.getOrderByIdAndMember(orderId, memberId);
         return ResponseEntity.ok(RsData.success("주문이 조회되었습니다.", resDto));
     }
 
@@ -70,5 +71,16 @@ public class OrderController {
         return ResponseEntity
             .status(HttpStatus.CREATED)
             .body(RsData.createSuccess("주문이 생성되었습니다.", orderId));
+    }
+
+    @PostMapping("{orderId}/cancel")
+    @Operation(summary = "주문 취소", description = "주문 취소 API")
+    public ResponseEntity<RsData<Void>> updateOrder(
+        @LogInMemberId Long memberId,
+        @PathVariable Long orderId,
+        @RequestBody @Valid ClaimOrderReqDto reqDto
+    ) {
+        orderFacade.cancelOrder(memberId, orderId, reqDto);
+        return ResponseEntity.ok(RsData.success("주문이 취소되었습니다.", null));
     }
 }

--- a/src/main/java/com/fittura/domain/order/order/dto/request/ClaimItemReqDto.java
+++ b/src/main/java/com/fittura/domain/order/order/dto/request/ClaimItemReqDto.java
@@ -1,0 +1,13 @@
+package com.fittura.domain.order.order.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
+public record ClaimItemReqDto(
+    @NotNull
+    Long orderItemId,
+
+    @NotNull @Positive
+    Integer quantity
+) {
+}

--- a/src/main/java/com/fittura/domain/order/order/dto/request/ClaimOrderReqDto.java
+++ b/src/main/java/com/fittura/domain/order/order/dto/request/ClaimOrderReqDto.java
@@ -1,0 +1,21 @@
+package com.fittura.domain.order.order.dto.request;
+
+import com.fittura.domain.order.order.constant.ClaimReason;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+import java.util.List;
+
+public record ClaimOrderReqDto(
+
+    @Valid @NotNull @Size(min = 1)
+    List<ClaimItemReqDto> claimItems,
+
+    @NotNull
+    ClaimReason reason,
+
+    @NotNull
+    String reasonDetail
+) {
+}

--- a/src/main/java/com/fittura/domain/order/order/entity/Claim.java
+++ b/src/main/java/com/fittura/domain/order/order/entity/Claim.java
@@ -1,0 +1,83 @@
+package com.fittura.domain.order.order.entity;
+
+import com.fittura.domain.order.order.constant.ClaimReason;
+import com.fittura.domain.order.order.constant.ClaimStatus;
+import com.fittura.domain.order.order.constant.ClaimType;
+import com.fittura.global.jpa.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import static lombok.AccessLevel.PRIVATE;
+import static lombok.AccessLevel.PROTECTED;
+
+@Getter
+@Entity
+@Table(name = "claim")
+@NoArgsConstructor(access = PROTECTED)
+@AllArgsConstructor(access = PRIVATE)
+@Builder(access = PRIVATE)
+public class Claim extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "order_id", nullable = false)
+    private Order order;
+
+    @Builder.Default
+    @OneToMany(mappedBy = "claim", cascade = CascadeType.ALL)
+    private List<ClaimItem> items = new ArrayList<>();
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private ClaimType claimType;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private ClaimStatus status;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private ClaimReason reason;
+
+    @Column
+    private String reasonDetail;
+
+    @Column(nullable = false)
+    private Long refundAmount;
+
+
+    // ===== 생성 =====
+
+    public static Claim create(
+        Order order,
+        ClaimType claimType,
+        ClaimReason reason,
+        String reasonDetail
+    ) {
+        Objects.requireNonNull(order, "order must not be null");
+
+        return Claim.builder()
+            .order(order)
+            .claimType(claimType)
+            .status(ClaimStatus.REQUESTED)
+            .reason(reason)
+            .reasonDetail(reasonDetail)
+            .refundAmount(0L)
+            .build();
+    }
+
+    public void addItem(ClaimItem item) {
+        items.add(item);
+        refundAmount += item.getRefundAmount();
+    }
+
+    public boolean isConfirmed() {
+        return status != ClaimStatus.REJECTED;
+    }
+}

--- a/src/main/java/com/fittura/domain/order/order/entity/Claim.java
+++ b/src/main/java/com/fittura/domain/order/order/entity/Claim.java
@@ -12,8 +12,11 @@ import lombok.NoArgsConstructor;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
+import static java.util.stream.Collectors.groupingBy;
+import static java.util.stream.Collectors.summingInt;
 import static lombok.AccessLevel.PRIVATE;
 import static lombok.AccessLevel.PROTECTED;
 
@@ -76,6 +79,27 @@ public class Claim extends BaseEntity {
         items.add(item);
         refundAmount += item.getRefundAmount();
     }
+
+    public Map<Long, Integer> getQuantityBySkuId() {
+        return items.stream()
+            .collect(groupingBy(
+                ci -> ci.getOrderItem().getSku().getId(),
+                summingInt(ClaimItem::getQuantity)
+            ));
+    }
+
+
+    // ===== 상태 =====
+
+    public void approve() {
+        this.status = ClaimStatus.APPROVED;
+    }
+
+    public void complete() {
+        this.status = ClaimStatus.COMPLETED;
+    }
+
+    public void reject() {}
 
     public boolean isConfirmed() {
         return status != ClaimStatus.REJECTED;

--- a/src/main/java/com/fittura/domain/order/order/entity/ClaimItem.java
+++ b/src/main/java/com/fittura/domain/order/order/entity/ClaimItem.java
@@ -1,0 +1,56 @@
+package com.fittura.domain.order.order.entity;
+
+import com.fittura.global.jpa.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Objects;
+
+import static lombok.AccessLevel.PRIVATE;
+import static lombok.AccessLevel.PROTECTED;
+
+@Getter
+@Entity
+@Table(name = "claim_item")
+@NoArgsConstructor(access = PROTECTED)
+@AllArgsConstructor(access = PRIVATE)
+@Builder(access = PRIVATE)
+public class ClaimItem extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "claim_id")
+    private Claim claim;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "order_item_id", nullable = false)
+    private OrderItem orderItem;
+
+    @Column(nullable = false)
+    private Integer quantity;
+
+    @Column(nullable = false)
+    private Long refundAmount;
+
+
+    // ===== 생성 =====
+
+    public static ClaimItem create(Claim claim, OrderItem orderItem, Integer claimQuantity) {
+        Objects.requireNonNull(claim, "claim must not be null");
+        Objects.requireNonNull(orderItem, "orderItem must not be null");
+
+        ClaimItem claimItem = ClaimItem.builder()
+            .claim(claim)
+            .orderItem(orderItem)
+            .quantity(claimQuantity)
+            .refundAmount(orderItem.calcRefundAmount(claimQuantity))
+            .build();
+
+        claim.addItem(claimItem);
+        orderItem.addClaimItem(claimItem);
+
+        return claimItem;
+    }
+}

--- a/src/main/java/com/fittura/domain/order/order/entity/Order.java
+++ b/src/main/java/com/fittura/domain/order/order/entity/Order.java
@@ -115,8 +115,19 @@ public class Order extends BaseEntity {
         finalAmount = totalAmount - discountAmount - pointUsedAmount + deliveryFee;
     }
 
+
+    // ===== 상태 =====
+
     public void prepare() {
         this.status = OrderStatus.PREPARING;
+    }
+
+    public void cancel() {
+        this.status = OrderStatus.CANCELLED;
+    }
+
+    public boolean isPaid() {
+        return status == OrderStatus.PAID;
     }
 
 
@@ -126,15 +137,14 @@ public class Order extends BaseEntity {
         switch (status) {
             case PAID, PREPARING: return;
             case COMPLETED: throw new ServiceException(OrderErrorCode.COMPLETED_CAN_NOT_CANCEL);
-            case CANCEL_REQUESTED: throw new ServiceException(OrderErrorCode.ALREADY_CANCEL_REQUESTED);
-            case PENDING, CANCELLED, RETURN_REQUESTED, RETURNED:
+            case PENDING, CANCELLED, RETURNED:
                 throw new ServiceException(OrderErrorCode.NOT_VALID_STATUS);
             default: throw new ServiceException(CommonErrorCode.INTERNAL_SERVER_ERROR);
         }
     }
 
 
-    // ===== private method =====
+    // ===== 헬퍼 메서드 =====
 
     private static void validateAmount(Long amount) {
         if (amount == null || amount < 0) {

--- a/src/main/java/com/fittura/domain/order/order/entity/Order.java
+++ b/src/main/java/com/fittura/domain/order/order/entity/Order.java
@@ -114,6 +114,10 @@ public class Order extends BaseEntity {
         finalAmount = totalAmount - discountAmount - pointUsedAmount + deliveryFee;
     }
 
+    public void prepare() {
+        this.status = OrderStatus.PREPARING;
+    }
+
     private static void validateAmount(Long amount) {
         if (amount == null || amount < 0) {
             throw new ServiceException(OrderErrorCode.AMOUNT_MUST_BE_POSITIVE);

--- a/src/main/java/com/fittura/domain/order/order/entity/Order.java
+++ b/src/main/java/com/fittura/domain/order/order/entity/Order.java
@@ -2,6 +2,7 @@ package com.fittura.domain.order.order.entity;
 
 import com.fittura.domain.order.order.constant.OrderStatus;
 import com.fittura.domain.order.order.error.OrderErrorCode;
+import com.fittura.global.error.CommonErrorCode;
 import com.fittura.global.exception.ServiceException;
 import com.fittura.global.jpa.entity.BaseEntity;
 import jakarta.persistence.*;
@@ -117,6 +118,23 @@ public class Order extends BaseEntity {
     public void prepare() {
         this.status = OrderStatus.PREPARING;
     }
+
+
+    //  ===== 유효성 검증 =====
+
+    public void validateCancel() {
+        switch (status) {
+            case PAID, PREPARING: return;
+            case COMPLETED: throw new ServiceException(OrderErrorCode.COMPLETED_CAN_NOT_CANCEL);
+            case CANCEL_REQUESTED: throw new ServiceException(OrderErrorCode.ALREADY_CANCEL_REQUESTED);
+            case PENDING, CANCELLED, RETURN_REQUESTED, RETURNED:
+                throw new ServiceException(OrderErrorCode.NOT_VALID_STATUS);
+            default: throw new ServiceException(CommonErrorCode.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+
+    // ===== private method =====
 
     private static void validateAmount(Long amount) {
         if (amount == null || amount < 0) {

--- a/src/main/java/com/fittura/domain/order/order/entity/OrderItem.java
+++ b/src/main/java/com/fittura/domain/order/order/entity/OrderItem.java
@@ -11,6 +11,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 
 import static lombok.AccessLevel.PRIVATE;
@@ -41,6 +43,10 @@ public class OrderItem extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "sku_id", nullable = false)
     private ProductSku sku;
+
+    @Builder.Default
+    @OneToMany(mappedBy = "orderItem", cascade = CascadeType.ALL)
+    private List<ClaimItem> claimItems = new ArrayList<>();
 
     @Column
     private Long deliveryId;
@@ -95,10 +101,23 @@ public class OrderItem extends BaseEntity {
         return orderItem;
     }
 
+    public void addClaimItem(ClaimItem claimItem) {
+        claimItems.add(claimItem);
+    }
+
     public void calcDiscountAmount(Long discountAmount) {
         // TODO: promotion 기능 때 반영 예정
         this.discountAmount = discountAmount;
         this.itemTotalAmount = itemTotalAmount - discountAmount;
+    }
+
+    public Long calcRefundAmount(int claimQuantity) {
+        int remaining = quantity - getTotalClaimQuantity();
+
+        if (claimQuantity == remaining) {
+            return itemTotalAmount - getTotalRefundedAmount();
+        }
+        return itemTotalAmount * claimQuantity / quantity;
     }
 
     public void assignDelivery(Long deliveryId) {
@@ -110,6 +129,13 @@ public class OrderItem extends BaseEntity {
         return status == OrderItemStatus.ORDERED;
     }
 
+
+    // ===== 유효성 검증 =====
+
+    public boolean isQuantityValid(Integer claimQuantity) {
+        return quantity - getTotalClaimQuantity() - claimQuantity >= 0;
+    }
+
     private static void validateQuantity(Integer quantity) {
         if (quantity == null || quantity < 1) {
             throw new ServiceException(OrderErrorCode.QUANTITY_MUST_BE_POSITIVE);
@@ -117,5 +143,19 @@ public class OrderItem extends BaseEntity {
         if (quantity > MAX_QUANTITY) {
             throw new ServiceException(OrderErrorCode.QUANTITY_EXCEEDED);
         }
+    }
+
+    private int getTotalClaimQuantity() {
+        return claimItems.stream()
+            .filter(ci -> ci.getClaim().isConfirmed())
+            .mapToInt(ClaimItem::getQuantity)
+            .sum();
+    }
+
+    private Long getTotalRefundedAmount() {
+        return claimItems.stream()
+            .filter(ci -> ci.getClaim().isConfirmed())
+            .mapToLong(ClaimItem::getRefundAmount)
+            .sum();
     }
 }

--- a/src/main/java/com/fittura/domain/order/order/entity/OrderItem.java
+++ b/src/main/java/com/fittura/domain/order/order/entity/OrderItem.java
@@ -125,10 +125,26 @@ public class OrderItem extends BaseEntity {
         this.deliveryId = deliveryId;
     }
 
+
+    // ===== 상태 =====
+
+    public void requestCancel() {
+        this.status = OrderItemStatus.CANCEL_REQUESTED;
+    }
+
+    public void reflectCancel() {
+        if (quantity == getTotalClaimQuantity()) {
+            this.status = OrderItemStatus.CANCELLED;
+        }
+    }
+
     public boolean isOrdered() {
         return status == OrderItemStatus.ORDERED;
     }
 
+    public boolean isCanceled() {
+        return status == OrderItemStatus.CANCELLED;
+    }
 
     // ===== 유효성 검증 =====
 
@@ -144,6 +160,9 @@ public class OrderItem extends BaseEntity {
             throw new ServiceException(OrderErrorCode.QUANTITY_EXCEEDED);
         }
     }
+
+
+    // ===== 헬퍼 메서드 =====
 
     private int getTotalClaimQuantity() {
         return claimItems.stream()

--- a/src/main/java/com/fittura/domain/order/order/entity/OrderItem.java
+++ b/src/main/java/com/fittura/domain/order/order/entity/OrderItem.java
@@ -106,6 +106,10 @@ public class OrderItem extends BaseEntity {
         this.deliveryId = deliveryId;
     }
 
+    public boolean isOrdered() {
+        return status == OrderItemStatus.ORDERED;
+    }
+
     private static void validateQuantity(Integer quantity) {
         if (quantity == null || quantity < 1) {
             throw new ServiceException(OrderErrorCode.QUANTITY_MUST_BE_POSITIVE);

--- a/src/main/java/com/fittura/domain/order/order/error/OrderErrorCode.java
+++ b/src/main/java/com/fittura/domain/order/order/error/OrderErrorCode.java
@@ -24,9 +24,11 @@ public enum OrderErrorCode implements ErrorCode {
     NOT_VALID_STATUS(HttpStatus.BAD_REQUEST, "OR400-12", "주문 상태를 확인해주세요."),
     NO_CANCELLABLE_ITEM(HttpStatus.BAD_REQUEST, "OR400-13", "취소 가능한 상품이 없습니다."),
     CLAIM_ITEMS_NOT_VALID(HttpStatus.BAD_REQUEST, "OR400-14" , "취소/반품/교환 불가한 상품이 있습니다." ),
+    QUANTITY_NOT_VALID(HttpStatus.BAD_REQUEST, "OR400-15" , "주문한 수량 이하로 취소/반품/교환 가능합니다." ),
 
     // 404
-    NOT_FOUND_ORDER(HttpStatus.NOT_FOUND, "OR404-01", "주문을 찾을 수 없습니다."),;
+    NOT_FOUND_ORDER(HttpStatus.NOT_FOUND, "OR404-01", "주문을 찾을 수 없습니다."),
+    NOT_FOUND_ORDER_ITEM(HttpStatus.NOT_FOUND, "OR404-02", "주문 상품을 찾을 수 없습니다." ),;
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/fittura/domain/order/order/error/OrderErrorCode.java
+++ b/src/main/java/com/fittura/domain/order/order/error/OrderErrorCode.java
@@ -19,9 +19,14 @@ public enum OrderErrorCode implements ErrorCode {
     STOCK_NOT_VALID(HttpStatus.BAD_REQUEST, "OR400-07" , "재고가 부족합니다."),
     DATE_RANGE_INVALID(HttpStatus.BAD_REQUEST, "OR400-08" , "주문 일자 조회 범위를 확인해주세요." ),
     DELIVERY_ORDER_MISMATCH(HttpStatus.BAD_REQUEST, "OR400-09" , "상품과 배송의 주문이 불일치합니다." ),
+    COMPLETED_CAN_NOT_CANCEL(HttpStatus.BAD_REQUEST, "OR400-10" , "배송 완료된 상태입니다. 반품 요청만 가능합니다." ),
+    ALREADY_CANCEL_REQUESTED(HttpStatus.BAD_REQUEST, "OR400-11" , "중복된 취소 요청입니다." ),
+    NOT_VALID_STATUS(HttpStatus.BAD_REQUEST, "OR400-12", "주문 상태를 확인해주세요."),
+    NO_CANCELLABLE_ITEM(HttpStatus.BAD_REQUEST, "OR400-13", "취소 가능한 상품이 없습니다."),
+    CLAIM_ITEMS_NOT_VALID(HttpStatus.BAD_REQUEST, "OR400-14" , "취소/반품/교환 불가한 상품이 있습니다." ),
 
     // 404
-    NOT_FOUND_ORDER(HttpStatus.NOT_FOUND, "OR404-01", "주문을 찾을 수 없습니다.");
+    NOT_FOUND_ORDER(HttpStatus.NOT_FOUND, "OR404-01", "주문을 찾을 수 없습니다."),;
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/fittura/domain/order/order/repository/ClaimItemRepository.java
+++ b/src/main/java/com/fittura/domain/order/order/repository/ClaimItemRepository.java
@@ -1,0 +1,7 @@
+package com.fittura.domain.order.order.repository;
+
+import com.fittura.domain.order.order.entity.ClaimItem;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ClaimItemRepository extends JpaRepository<ClaimItem, Long> {
+}

--- a/src/main/java/com/fittura/domain/order/order/repository/ClaimRepository.java
+++ b/src/main/java/com/fittura/domain/order/order/repository/ClaimRepository.java
@@ -1,0 +1,7 @@
+package com.fittura.domain.order.order.repository;
+
+import com.fittura.domain.order.order.entity.Claim;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ClaimRepository extends JpaRepository<Claim, Long> {
+}

--- a/src/main/java/com/fittura/domain/order/order/repository/OrderRepository.java
+++ b/src/main/java/com/fittura/domain/order/order/repository/OrderRepository.java
@@ -2,8 +2,19 @@ package com.fittura.domain.order.order.repository;
 
 import com.fittura.domain.order.order.entity.Order;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
 
 @Repository
 public interface OrderRepository extends JpaRepository<Order, Long>, OrderRepositoryCustom {
+    @Query("""
+        SELECT o FROM Order o
+        JOIN FETCH o.items oi
+        WHERE o.id = :orderId
+        AND o.memberId = :memberId
+        """)
+    Optional<Order> findByIdAndMemberId(@Param("orderId") Long orderId, @Param("memberId") Long memberId);
 }

--- a/src/main/java/com/fittura/domain/order/order/repository/OrderRepositoryImpl.java
+++ b/src/main/java/com/fittura/domain/order/order/repository/OrderRepositoryImpl.java
@@ -18,6 +18,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static com.fittura.domain.delivery.delivery.entitiy.QDelivery.delivery;
+import static com.fittura.domain.order.order.constant.OrderStatus.*;
 import static com.fittura.domain.order.order.entity.QOrder.order;
 import static com.fittura.domain.order.order.entity.QOrderAddress.orderAddress;
 import static com.fittura.domain.order.order.entity.QOrderItem.orderItem;
@@ -33,6 +34,7 @@ public class OrderRepositoryImpl implements OrderRepositoryCustom {
             order.memberId.eq(memberId),
             order.orderDate.goe(condition.startDate()),
             order.orderDate.lt(condition.endDate()),
+            order.status.in(PAID, PREPARING, COMPLETED, CANCEL_REQUESTED, CANCELLED, RETURN_REQUESTED, RETURNED),
             orderNumberEq(condition.orderNumber()),
             productNameContains(condition.productName())
         };

--- a/src/main/java/com/fittura/domain/order/order/service/OrderService.java
+++ b/src/main/java/com/fittura/domain/order/order/service/OrderService.java
@@ -1,15 +1,13 @@
 package com.fittura.domain.order.order.service;
 
 import com.fittura.domain.order.cart.entity.CartItem;
-import com.fittura.domain.order.order.dto.request.AddressCreateReqDto;
-import com.fittura.domain.order.order.dto.request.OrderCreateReqDto;
-import com.fittura.domain.order.order.dto.request.OrderSearchCondition;
+import com.fittura.domain.order.order.constant.ClaimType;
+import com.fittura.domain.order.order.dto.request.*;
 import com.fittura.domain.order.order.dto.response.OrderWithAllResDto;
 import com.fittura.domain.order.order.dto.response.OrderWithDeliveryResDto;
-import com.fittura.domain.order.order.entity.Order;
-import com.fittura.domain.order.order.entity.OrderAddress;
-import com.fittura.domain.order.order.entity.OrderItem;
+import com.fittura.domain.order.order.entity.*;
 import com.fittura.domain.order.order.error.OrderErrorCode;
+import com.fittura.domain.order.order.repository.ClaimRepository;
 import com.fittura.domain.order.order.repository.OrderAddressRepository;
 import com.fittura.domain.order.order.repository.OrderItemRepository;
 import com.fittura.domain.order.order.repository.OrderRepository;
@@ -23,6 +21,8 @@ import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -31,6 +31,7 @@ public class OrderService {
     private final OrderRepository orderRepository;
     private final OrderItemRepository orderItemRepository;
     private final OrderAddressRepository addressRepository;
+    private final ClaimRepository claimRepository;
 
     // ========== 주문 ==========
 
@@ -83,6 +84,31 @@ public class OrderService {
     }
 
 
+    // ========== 취소/환불/교환 ==========
+
+    public Claim createCancelClaim(Order order, ClaimOrderReqDto reqDto) {
+        Map<Long, Integer> quantityByItemId = reqDto.claimItems().stream()
+            .collect(Collectors.toMap(
+                ClaimItemReqDto::orderItemId,
+                ClaimItemReqDto::quantity
+            ));
+
+        List<OrderItem> orderItems = order.getItems().stream()
+            .filter(oi -> quantityByItemId.containsKey(oi.getId()))
+            .toList();
+
+        validateClaimItems(orderItems, quantityByItemId);
+
+        Claim claim = Claim.create(order, ClaimType.CANCEL, reqDto.reason(), reqDto.reasonDetail());
+        for (OrderItem orderItem : orderItems) {
+            ClaimItem.create(claim, orderItem, quantityByItemId.get(orderItem.getId()));
+        }
+        claimRepository.save(claim);
+
+        return claim;
+    }
+
+
     // ========== 유효성 검사 ==========
 
     public void validateCartItems(List<CartItem> cartItems) {
@@ -106,19 +132,23 @@ public class OrderService {
         }
     }
 
-    public void validateOrderItems(List<OrderItem> orderItems) {
+    private void validateClaimItems(List<OrderItem> orderItems, Map<Long, Integer> quantityByItemId) {
+        if (orderItems.size() != quantityByItemId.size()) {
+            throw new ServiceException(OrderErrorCode.NOT_FOUND_ORDER_ITEM);
+        }
+
         List<ItemError> errors = new ArrayList<>();
 
         for (OrderItem orderItem : orderItems) {
             if (!orderItem.isOrdered()) {
                 errors.add(ItemError.of(orderItem.getProductName(), OrderErrorCode.NOT_VALID_STATUS));
+            } else if (!orderItem.isQuantityValid(quantityByItemId.get(orderItem.getId()))) {
+                errors.add(ItemError.of(orderItem.getProductName(), OrderErrorCode.QUANTITY_NOT_VALID));
             }
-
-            // TODO: claim 수량 체크
         }
 
         if (!errors.isEmpty()) {
-            throw new ServiceException(OrderErrorCode.CLAIM_ITEMS_NOT_VALID);
+            throw new ServiceException(OrderErrorCode.CLAIM_ITEMS_NOT_VALID, errors);
         }
     }
 }

--- a/src/main/java/com/fittura/domain/order/order/service/OrderService.java
+++ b/src/main/java/com/fittura/domain/order/order/service/OrderService.java
@@ -87,17 +87,8 @@ public class OrderService {
     // ========== 취소/환불/교환 ==========
 
     public Claim createCancelClaim(Order order, ClaimOrderReqDto reqDto) {
-        Map<Long, Integer> quantityByItemId = reqDto.claimItems().stream()
-            .collect(Collectors.toMap(
-                ClaimItemReqDto::orderItemId,
-                ClaimItemReqDto::quantity
-            ));
-
-        List<OrderItem> orderItems = order.getItems().stream()
-            .filter(oi -> quantityByItemId.containsKey(oi.getId()))
-            .toList();
-
-        validateClaimItems(orderItems, quantityByItemId);
+        Map<Long, Integer> quantityByItemId = getQuantityByItemId(reqDto);
+        List<OrderItem> orderItems = getClaimItems(order, quantityByItemId);
 
         Claim claim = Claim.create(order, ClaimType.CANCEL, reqDto.reason(), reqDto.reasonDetail());
         for (OrderItem orderItem : orderItems) {
@@ -106,6 +97,20 @@ public class OrderService {
         claimRepository.save(claim);
 
         return claim;
+    }
+
+    public void requestCancel(Order order, List<ClaimItem> claimItems) {
+        claimItems.forEach(ci -> ci.getOrderItem().requestCancel());
+    }
+
+    public void cancelItems(List<ClaimItem> claimItems) {
+        claimItems.forEach(ci -> ci.getOrderItem().reflectCancel());
+    }
+
+    public void cancelIfAllItemsCancelled(Order order) {
+        boolean allCancelled = order.getItems().stream().allMatch(OrderItem::isCanceled);
+
+        if (allCancelled) order.cancel();
     }
 
 
@@ -150,5 +155,25 @@ public class OrderService {
         if (!errors.isEmpty()) {
             throw new ServiceException(OrderErrorCode.CLAIM_ITEMS_NOT_VALID, errors);
         }
+    }
+
+
+    // ========== 헬퍼 메서드 ==========
+
+    private Map<Long, Integer> getQuantityByItemId(ClaimOrderReqDto reqDto) {
+        return reqDto.claimItems().stream()
+            .collect(Collectors.toMap(
+                ClaimItemReqDto::orderItemId,
+                ClaimItemReqDto::quantity
+            ));
+    }
+
+    private List<OrderItem> getClaimItems(Order order, Map<Long, Integer> quantityByItemId) {
+        List<OrderItem> orderItems = order.getItems().stream()
+            .filter(oi -> quantityByItemId.containsKey(oi.getId()))
+            .toList();
+
+        validateClaimItems(orderItems, quantityByItemId);
+        return orderItems;
     }
 }

--- a/src/main/java/com/fittura/domain/order/order/service/OrderService.java
+++ b/src/main/java/com/fittura/domain/order/order/service/OrderService.java
@@ -38,7 +38,7 @@ public class OrderService {
         return orderRepository.findOrders(memberId, searchCondition, pageable);
     }
 
-    public OrderWithAllResDto getOrderByIdAndMember(Long orderId, Long memberId) {
+    public OrderWithAllResDto getOrderDetail(Long orderId, Long memberId) {
         return orderRepository.findWithAllByIdAndMemberId(orderId, memberId)
             .orElseThrow(() -> new ServiceException(OrderErrorCode.NOT_FOUND_ORDER));
     }

--- a/src/main/java/com/fittura/domain/order/order/service/OrderService.java
+++ b/src/main/java/com/fittura/domain/order/order/service/OrderService.java
@@ -4,8 +4,8 @@ import com.fittura.domain.order.cart.entity.CartItem;
 import com.fittura.domain.order.order.dto.request.AddressCreateReqDto;
 import com.fittura.domain.order.order.dto.request.OrderCreateReqDto;
 import com.fittura.domain.order.order.dto.request.OrderSearchCondition;
-import com.fittura.domain.order.order.dto.response.OrderWithDeliveryResDto;
 import com.fittura.domain.order.order.dto.response.OrderWithAllResDto;
+import com.fittura.domain.order.order.dto.response.OrderWithDeliveryResDto;
 import com.fittura.domain.order.order.entity.Order;
 import com.fittura.domain.order.order.entity.OrderAddress;
 import com.fittura.domain.order.order.entity.OrderItem;
@@ -40,6 +40,11 @@ public class OrderService {
 
     public OrderWithAllResDto getOrderDetail(Long orderId, Long memberId) {
         return orderRepository.findWithAllByIdAndMemberId(orderId, memberId)
+            .orElseThrow(() -> new ServiceException(OrderErrorCode.NOT_FOUND_ORDER));
+    }
+
+    public Order getOrder(Long orderId, Long memberId) {
+        return orderRepository.findByIdAndMemberId(orderId, memberId)
             .orElseThrow(() -> new ServiceException(OrderErrorCode.NOT_FOUND_ORDER));
     }
 
@@ -98,6 +103,22 @@ public class OrderService {
 
         if (!errors.isEmpty()) {
             throw new ServiceException(OrderErrorCode.CART_ITEMS_NOT_VALID, errors);
+        }
+    }
+
+    public void validateOrderItems(List<OrderItem> orderItems) {
+        List<ItemError> errors = new ArrayList<>();
+
+        for (OrderItem orderItem : orderItems) {
+            if (!orderItem.isOrdered()) {
+                errors.add(ItemError.of(orderItem.getProductName(), OrderErrorCode.NOT_VALID_STATUS));
+            }
+
+            // TODO: claim 수량 체크
+        }
+
+        if (!errors.isEmpty()) {
+            throw new ServiceException(OrderErrorCode.CLAIM_ITEMS_NOT_VALID);
         }
     }
 }

--- a/src/main/java/com/fittura/domain/product/sku/repository/ProductSkuRepository.java
+++ b/src/main/java/com/fittura/domain/product/sku/repository/ProductSkuRepository.java
@@ -3,6 +3,9 @@ package com.fittura.domain.product.sku.repository;
 import com.fittura.domain.product.sku.constant.SkuStatus;
 import com.fittura.domain.product.sku.entity.ProductSku;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -15,4 +18,8 @@ public interface ProductSkuRepository extends JpaRepository<ProductSku, Long> {
     Optional<ProductSku> findByIdAndStatusNot(Long skuId, SkuStatus status);
 
     boolean existsByProductIdAndId(Long productId, Long skuId);
+
+    @Modifying
+    @Query("update ProductSku s set s.stockQuantity = s.stockQuantity + :restoreQuantity where s.id = :skuId")
+    void restoreStock(@Param("skuId") Long skuId, @Param("restoreQuantity") Integer restoreQuantity);
 }

--- a/src/main/java/com/fittura/domain/product/sku/service/SkuService.java
+++ b/src/main/java/com/fittura/domain/product/sku/service/SkuService.java
@@ -107,6 +107,10 @@ public class SkuService {
         }
     }
 
+    public void restoreStock(Map<Long, Integer> quantityBySkuId) {
+        quantityBySkuId.forEach(productSkuRepository::restoreStock);
+    }
+
 
     // ========== 구성품 ==========
 

--- a/src/test/java/com/fittura/domain/order/order/controller/OrderControllerTest.java
+++ b/src/test/java/com/fittura/domain/order/order/controller/OrderControllerTest.java
@@ -557,6 +557,7 @@ class OrderControllerTest extends IntegrationTestBase {
         Order order = OrderFixture.order(memberId, 1000L);
         OrderItemFixture.orderItem(order, sku, quantity);
         order.calcFinalAmount();
+        order.prepare();
         orderRepository.save(order);
 
         OrderAddress address = OrderAddressFixture.address(order);
@@ -569,6 +570,7 @@ class OrderControllerTest extends IntegrationTestBase {
         Order order = OrderFixture.order(memberId, 0L);
         OrderItem item = OrderItemFixture.orderItem(order, sku, quantity);
         order.calcFinalAmount();
+        order.prepare();
         orderRepository.save(order);
 
         OrderAddress address = OrderAddressFixture.address(order);
@@ -588,6 +590,7 @@ class OrderControllerTest extends IntegrationTestBase {
         OrderItem parcelItem = OrderItemFixture.orderItem(order, parcelSku, 1);
         OrderItem installItem = OrderItemFixture.orderItem(order, installSku, 1);
         order.calcFinalAmount();
+        order.prepare();
         orderRepository.save(order);
 
         OrderAddress address = OrderAddressFixture.address(order);

--- a/src/test/java/com/fittura/domain/order/order/service/OrderServiceTest.java
+++ b/src/test/java/com/fittura/domain/order/order/service/OrderServiceTest.java
@@ -59,7 +59,7 @@ class OrderServiceTest {
 
     @Test
     @DisplayName("주문 조회 성공")
-    void getOrderByIdAndMemberSuccess() {
+    void getOrderDetailSuccess() {
         // given
         Long orderId = 1L;
         Long memberId = 1L;
@@ -76,7 +76,7 @@ class OrderServiceTest {
             .willReturn(Optional.of(dto));
 
         // when
-        OrderWithAllResDto result = orderService.getOrderByIdAndMember(orderId, memberId);
+        OrderWithAllResDto result = orderService.getOrderDetail(orderId, memberId);
 
         // then
         assertThat(result).isEqualTo(dto);
@@ -84,7 +84,7 @@ class OrderServiceTest {
 
     @Test
     @DisplayName("주문 조회 실패 - 존재하지 않거나 본인 주문 아님")
-    void getOrderByIdAndMemberFail_notFound() {
+    void getOrderDetailFail_notFound() {
         // given
         Long orderId = 999L;
         Long memberId = 1L;
@@ -92,7 +92,7 @@ class OrderServiceTest {
             .willReturn(Optional.empty());
 
         // when & then
-        assertThatThrownBy(() -> orderService.getOrderByIdAndMember(orderId, memberId))
+        assertThatThrownBy(() -> orderService.getOrderDetail(orderId, memberId))
             .isInstanceOf(ServiceException.class)
             .satisfies(e -> assertThat(((ServiceException) e).getErrorCode())
                 .isEqualTo(OrderErrorCode.NOT_FOUND_ORDER));


### PR DESCRIPTION
## 기능 설명
주문 취소 골격

## 주요 사항
- 재고 롤백
- 주문 취소 골격 (배송 전 즉시 취소, 배송 이후 취소 요청)
- Claim 도입
- Delivery, Payment, Point구현 전이라 관련 로직과 취소 관리자 승인은 TODO
- Enforce PR source branch 깃설정 추가

## 관련 이슈
Closes #91 